### PR TITLE
将 Go 代理默认值更新为 goproxy.cn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN if [ -n "$ALPINE_MIRROR" ]; then \
     fi
 
 # 配置 Go 代理（使用 ENV 持久化到运行时）
-ENV GOPROXY=${GO_PROXY:-https://proxy.golang.org,direct}
+ENV GOPROXY=${GO_PROXY:-https://goproxy.cn,direct}
 ENV GO111MODULE=on
 
 # 安装必要的构建工具（纯 Go 编译，无需 CGO）


### PR DESCRIPTION
将 GOPROXY 环境变量的默认镜像源从 proxy.golang.org 更改为 goproxy.cn，以改善在中国大陆地区的依赖下载速度和可靠性。