### PR TITLE
fix: Fix the issue MiniMax videos fail to download

### DIFF
--- a/pkg/video/minimax_client.go
+++ b/pkg/video/minimax_client.go
@@ -87,12 +87,12 @@ type MinimaxQueryResponse struct {
 // MinimaxFileResponse 获取文件信息的响应
 type MinimaxFileResponse struct {
 	File struct {
-		FileID      string `json:"file_id"`
-		Bytes       int    `json:"bytes"`
-		CreatedAt   int64  `json:"created_at"`
-		Filename    string `json:"filename"`
-		Purpose     string `json:"purpose"`
-		DownloadURL string `json:"download_url"`
+		FileID      interface{} `json:"file_id"` // 可能是 string 或 number
+		Bytes       int         `json:"bytes"`
+		CreatedAt   int64       `json:"created_at"`
+		Filename    string      `json:"filename"`
+		Purpose     string      `json:"purpose"`
+		DownloadURL string      `json:"download_url"`
 	} `json:"file"`
 	BaseResp struct {
 		StatusCode int    `json:"status_code"`


### PR DESCRIPTION
When generating videos using MiniMax, the video generation task is created successfully, but an error occurs when downloading the video. The logs are as follows:
```
INFO	Starting video generation	{"id": 6, "prompt": "...", "provider": "minimax"}
INFO	HTTP Request	{"method": "POST", "path": "/api/v1/videos", "query": "", "status": 200, "duration": 2337, "ip": "103.172.81.25", "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"}
INFO	Video generation in progress	{"id": 6, "attempt": 1}
...
INFO	HTTP Request	{"method": "GET", "path": "/api/v1/videos", "query": "storyboard_id=1&page=1&page_size=50", "status": 200, "duration": 2374, "ip": "103.172.81.25", "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"}
ERROR	Failed to get task status	{"error": "failed to get download URL: parse response: json: cannot unmarshal number into Go struct field .file.file_id of type string", "task_id": "359690885259366"}
github.com/drama-generator/backend/application/services.(*VideoGenerationService).pollTaskStatus
	/app/application/services/video_generation_service.go:297
```