### PR TITLE
fix: complete OpenAI image generation/edit support and keep provider compatibility

### DIFF
--- a/application/services/image_generation_service.go
+++ b/application/services/image_generation_service.go
@@ -510,10 +510,10 @@ func (s *ImageGenerationService) getImageClient(provider string) (image.ImageCli
 	switch actualProvider {
 	case "openai", "dalle":
 		endpoint = "/images/generations"
-		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
+		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint, true), nil
 	case "chatfire":
 		endpoint = "/images/generations"
-		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
+		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint, false), nil
 	case "volcengine", "volces", "doubao":
 		endpoint = "/images/generations"
 		queryEndpoint = ""
@@ -523,7 +523,7 @@ func (s *ImageGenerationService) getImageClient(provider string) (image.ImageCli
 		return image.NewGeminiImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
 	default:
 		endpoint = "/images/generations"
-		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
+		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint, false), nil
 	}
 }
 
@@ -568,10 +568,10 @@ func (s *ImageGenerationService) getImageClientWithModel(provider string, modelN
 	switch actualProvider {
 	case "openai", "dalle":
 		endpoint = "/images/generations"
-		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
+		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint, true), nil
 	case "chatfire":
 		endpoint = "/images/generations"
-		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
+		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint, false), nil
 	case "volcengine", "volces", "doubao":
 		endpoint = "/images/generations"
 		queryEndpoint = ""
@@ -581,7 +581,7 @@ func (s *ImageGenerationService) getImageClientWithModel(provider string, modelN
 		return image.NewGeminiImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
 	default:
 		endpoint = "/images/generations"
-		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint), nil
+		return image.NewOpenAIImageClient(config.BaseURL, config.APIKey, model, endpoint, false), nil
 	}
 }
 

--- a/pkg/image/openai_image_client.go
+++ b/pkg/image/openai_image_client.go
@@ -2,47 +2,57 @@ package image
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"net/url"
+	"path"
+	"strings"
 	"time"
 )
 
 type OpenAIImageClient struct {
-	BaseURL    string
-	APIKey     string
-	Model      string
-	Endpoint   string
-	HTTPClient *http.Client
+	BaseURL      string
+	APIKey       string
+	Model        string
+	Endpoint     string
+	StrictOpenAI bool
+	HTTPClient   *http.Client
 }
 
-type DALLERequest struct {
-	Model   string   `json:"model"`
-	Prompt  string   `json:"prompt"`
-	Size    string   `json:"size,omitempty"`
-	Quality string   `json:"quality,omitempty"`
-	N       int      `json:"n"`
-	Image   []string `json:"image,omitempty"`
+type openAIImageRequest struct {
+	Model          string `json:"model,omitempty"`
+	Prompt         string `json:"prompt"`
+	Size           string `json:"size,omitempty"`
+	Quality        string `json:"quality,omitempty"`
+	Style          string `json:"style,omitempty"`
+	ResponseFormat string `json:"response_format,omitempty"`
+	N              int    `json:"n,omitempty"`
 }
 
-type DALLEResponse struct {
+type openAIImageResponse struct {
 	Created int64 `json:"created"`
 	Data    []struct {
 		URL           string `json:"url"`
+		B64JSON       string `json:"b64_json"`
 		RevisedPrompt string `json:"revised_prompt,omitempty"`
 	} `json:"data"`
 }
 
-func NewOpenAIImageClient(baseURL, apiKey, model, endpoint string) *OpenAIImageClient {
+func NewOpenAIImageClient(baseURL, apiKey, model, endpoint string, strictOpenAI bool) *OpenAIImageClient {
 	if endpoint == "" {
-		endpoint = "/v1/images/generations"
+		endpoint = "/images/generations"
 	}
 	return &OpenAIImageClient{
-		BaseURL:  baseURL,
-		APIKey:   apiKey,
-		Model:    model,
-		Endpoint: endpoint,
+		BaseURL:      baseURL,
+		APIKey:       apiKey,
+		Model:        model,
+		Endpoint:     endpoint,
+		StrictOpenAI: strictOpenAI,
 		HTTPClient: &http.Client{
 			Timeout: 10 * time.Minute,
 		},
@@ -50,10 +60,7 @@ func NewOpenAIImageClient(baseURL, apiKey, model, endpoint string) *OpenAIImageC
 }
 
 func (c *OpenAIImageClient) GenerateImage(prompt string, opts ...ImageOption) (*ImageResult, error) {
-	options := &ImageOptions{
-		Size:    "1920x1920",
-		Quality: "standard",
-	}
+	options := &ImageOptions{}
 
 	for _, opt := range opts {
 		opt(options)
@@ -64,65 +71,495 @@ func (c *OpenAIImageClient) GenerateImage(prompt string, opts ...ImageOption) (*
 		model = options.Model
 	}
 
-	reqBody := DALLERequest{
-		Model:   model,
-		Prompt:  prompt,
-		Size:    options.Size,
-		Quality: options.Quality,
-		N:       1,
-		Image:   options.ReferenceImages,
+	fullPrompt := composeOpenAIImagePrompt(prompt, options.NegativePrompt)
+
+	if !c.StrictOpenAI {
+		return c.generateLegacyCompatible(fullPrompt, model, options)
 	}
 
-	jsonData, err := json.Marshal(reqBody)
+	if len(options.ReferenceImages) > 0 {
+		return c.generateWithOpenAIEdit(fullPrompt, model, options)
+	}
+	return c.generateWithOpenAIGenerations(fullPrompt, model, options)
+}
+
+func (c *OpenAIImageClient) generateLegacyCompatible(prompt, model string, options *ImageOptions) (*ImageResult, error) {
+	size := options.Size
+	if size == "" {
+		size = "1024x1024"
+	}
+	quality := options.Quality
+	if quality == "" {
+		quality = "standard"
+	}
+
+	reqBody := map[string]interface{}{
+		"model":   model,
+		"prompt":  prompt,
+		"size":    size,
+		"quality": quality,
+		"n":       1,
+	}
+	if len(options.ReferenceImages) > 0 {
+		reqBody["image"] = options.ReferenceImages
+	}
+
+	payload, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	url := c.BaseURL + c.Endpoint
-	fmt.Printf("[OpenAI Image] Request URL: %s\n", url)
-	fmt.Printf("[OpenAI Image] Request Body: %s\n", string(jsonData))
+	respBody, err := c.sendJSONRequest(c.Endpoint, payload)
+	if err != nil {
+		return nil, err
+	}
+	return parseOpenAIImageResponse(respBody)
+}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+func (c *OpenAIImageClient) generateWithOpenAIGenerations(prompt, model string, options *ImageOptions) (*ImageResult, error) {
+	normalizedModel := normalizeModelName(model)
+	size := normalizeOpenAIImageSize(normalizedModel, options.Size, false)
+	quality, okQuality := normalizeOpenAIQuality(normalizedModel, options.Quality, false)
+	style, okStyle := normalizeOpenAIStyle(normalizedModel, options.Style)
+
+	reqBody := openAIImageRequest{
+		Model:  model,
+		Prompt: prompt,
+		Size:   size,
+		N:      1,
+	}
+	if okQuality {
+		reqBody.Quality = quality
+	}
+	if okStyle {
+		reqBody.Style = style
+	}
+	// DALL-E 支持 url，能复用既有下载逻辑；GPT Image 总是返回 b64_json。
+	if isDALLE2Model(normalizedModel) || isDALLE3Model(normalizedModel) {
+		reqBody.ResponseFormat = "url"
+	}
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	respBody, err := c.sendJSONRequest(c.Endpoint, payload)
+	if err != nil {
+		return nil, err
+	}
+	return parseOpenAIImageResponse(respBody)
+}
+
+func (c *OpenAIImageClient) generateWithOpenAIEdit(prompt, model string, options *ImageOptions) (*ImageResult, error) {
+	normalizedModel := normalizeModelName(model)
+	if isDALLE3Model(normalizedModel) {
+		return nil, fmt.Errorf("openai image edit does not support model %q; use gpt-image-* or dall-e-2", model)
+	}
+
+	size := normalizeOpenAIImageSize(normalizedModel, options.Size, true)
+	quality, okQuality := normalizeOpenAIQuality(normalizedModel, options.Quality, true)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	if model != "" {
+		if err := writer.WriteField("model", model); err != nil {
+			return nil, fmt.Errorf("write model field: %w", err)
+		}
+	}
+	if err := writer.WriteField("prompt", prompt); err != nil {
+		return nil, fmt.Errorf("write prompt field: %w", err)
+	}
+	if size != "" {
+		if err := writer.WriteField("size", size); err != nil {
+			return nil, fmt.Errorf("write size field: %w", err)
+		}
+	}
+	if okQuality {
+		if err := writer.WriteField("quality", quality); err != nil {
+			return nil, fmt.Errorf("write quality field: %w", err)
+		}
+	}
+
+	fieldName := "image"
+	if len(options.ReferenceImages) > 1 {
+		fieldName = "image[]"
+	}
+	for idx, ref := range options.ReferenceImages {
+		filename, mimeType, fileData, err := c.resolveReferenceImage(ref, idx)
+		if err != nil {
+			return nil, fmt.Errorf("invalid reference image[%d]: %w", idx, err)
+		}
+		part, err := createImageFormPart(writer, fieldName, filename, mimeType)
+		if err != nil {
+			return nil, fmt.Errorf("create image part[%d]: %w", idx, err)
+		}
+		if _, err := part.Write(fileData); err != nil {
+			return nil, fmt.Errorf("write image part[%d]: %w", idx, err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	respBody, err := c.sendMultipartRequest(c.editsEndpoint(), body, writer.FormDataContentType())
+	if err != nil {
+		return nil, err
+	}
+	return parseOpenAIImageResponse(respBody)
+}
+
+func (c *OpenAIImageClient) sendJSONRequest(endpoint string, payload []byte) ([]byte, error) {
+	reqURL := joinURL(c.BaseURL, endpoint)
+	req, err := http.NewRequest("POST", reqURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	return c.do(req)
+}
 
+func (c *OpenAIImageClient) sendMultipartRequest(endpoint string, body *bytes.Buffer, contentType string) ([]byte, error) {
+	reqURL := joinURL(c.BaseURL, endpoint)
+	req, err := http.NewRequest("POST", reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	return c.do(req)
+}
+
+func (c *OpenAIImageClient) do(req *http.Request) ([]byte, error) {
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("send request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("openai api error (status %d): %s", resp.StatusCode, string(respBody))
 	}
+	return respBody, nil
+}
 
-	fmt.Printf("OpenAI API Response: %s\n", string(body))
-
-	var result DALLEResponse
+func parseOpenAIImageResponse(body []byte) (*ImageResult, error) {
+	var result openAIImageResponse
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("parse response: %w, body: %s", err, string(body))
 	}
-
 	if len(result.Data) == 0 {
 		return nil, fmt.Errorf("no image generated, response: %s", string(body))
 	}
 
-	return &ImageResult{
-		Status:    "completed",
-		ImageURL:  result.Data[0].URL,
-		Completed: true,
-	}, nil
+	if result.Data[0].URL != "" {
+		return &ImageResult{
+			Status:    "completed",
+			ImageURL:  result.Data[0].URL,
+			Completed: true,
+		}, nil
+	}
+
+	if result.Data[0].B64JSON != "" {
+		decoded, err := decodeBase64(result.Data[0].B64JSON)
+		if err != nil {
+			return nil, fmt.Errorf("decode b64_json: %w", err)
+		}
+		dataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString(decoded)
+		return &ImageResult{
+			Status:    "completed",
+			ImageURL:  dataURI,
+			Completed: true,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no image url or b64_json in response: %s", string(body))
 }
 
 func (c *OpenAIImageClient) GetTaskStatus(taskID string) (*ImageResult, error) {
 	return nil, fmt.Errorf("not supported for OpenAI/DALL-E")
+}
+
+func (c *OpenAIImageClient) editsEndpoint() string {
+	endpoint := strings.TrimSpace(c.Endpoint)
+	if endpoint == "" {
+		return "/images/edits"
+	}
+	if strings.Contains(endpoint, "/images/generations") {
+		return strings.Replace(endpoint, "/images/generations", "/images/edits", 1)
+	}
+	return "/images/edits"
+}
+
+func (c *OpenAIImageClient) resolveReferenceImage(ref string, idx int) (filename string, mimeType string, data []byte, err error) {
+	if strings.HasPrefix(ref, "data:") {
+		return decodeDataURI(ref, idx)
+	}
+	if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") {
+		return c.downloadReferenceImage(ref, idx)
+	}
+	decoded, err := decodeBase64(ref)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("unsupported reference image format (need data URI, URL, or base64): %w", err)
+	}
+	mimeType = http.DetectContentType(decoded)
+	return fmt.Sprintf("reference-%d%s", idx+1, extensionByMIME(mimeType)), mimeType, decoded, nil
+}
+
+func (c *OpenAIImageClient) downloadReferenceImage(rawURL string, idx int) (filename string, mimeType string, data []byte, err error) {
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return "", "", nil, err
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return "", "", nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", nil, fmt.Errorf("download image failed with status %d", resp.StatusCode)
+	}
+	data, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", nil, err
+	}
+	mimeType = strings.TrimSpace(strings.Split(resp.Header.Get("Content-Type"), ";")[0])
+	if mimeType == "" {
+		mimeType = http.DetectContentType(data)
+	}
+	filename = filenameFromURL(rawURL)
+	if filename == "" {
+		filename = fmt.Sprintf("reference-%d%s", idx+1, extensionByMIME(mimeType))
+	}
+	return filename, mimeType, data, nil
+}
+
+func createImageFormPart(writer *multipart.Writer, fieldName, filename, mimeType string) (io.Writer, error) {
+	headers := make(textproto.MIMEHeader)
+	headers.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fieldName, filename))
+	if mimeType != "" {
+		headers.Set("Content-Type", mimeType)
+	} else {
+		headers.Set("Content-Type", "application/octet-stream")
+	}
+	return writer.CreatePart(headers)
+}
+
+func decodeDataURI(dataURI string, idx int) (filename string, mimeType string, data []byte, err error) {
+	parts := strings.SplitN(dataURI, ",", 2)
+	if len(parts) != 2 {
+		return "", "", nil, fmt.Errorf("invalid data URI")
+	}
+	meta := parts[0]
+	payload := parts[1]
+	if !strings.HasPrefix(meta, "data:") || !strings.Contains(meta, ";base64") {
+		return "", "", nil, fmt.Errorf("unsupported data URI format")
+	}
+	mimeType = strings.TrimPrefix(strings.Split(meta, ";")[0], "data:")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	decoded, err := decodeBase64(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("decode data URI: %w", err)
+	}
+	filename = fmt.Sprintf("reference-%d%s", idx+1, extensionByMIME(mimeType))
+	return filename, mimeType, decoded, nil
+}
+
+func decodeBase64(v string) ([]byte, error) {
+	clean := strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t', ' ':
+			return -1
+		default:
+			return r
+		}
+	}, v)
+	if b, err := base64.StdEncoding.DecodeString(clean); err == nil {
+		return b, nil
+	}
+	if b, err := base64.RawStdEncoding.DecodeString(clean); err == nil {
+		return b, nil
+	}
+	return nil, fmt.Errorf("invalid base64 data")
+}
+
+func filenameFromURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	base := path.Base(parsed.Path)
+	if base == "." || base == "/" || base == "" {
+		return ""
+	}
+	return base
+}
+
+func extensionByMIME(mimeType string) string {
+	switch strings.ToLower(strings.TrimSpace(mimeType)) {
+	case "image/png":
+		return ".png"
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	default:
+		return ".bin"
+	}
+}
+
+func composeOpenAIImagePrompt(prompt, negativePrompt string) string {
+	if strings.TrimSpace(negativePrompt) == "" {
+		return prompt
+	}
+	return fmt.Sprintf("%s\n\nNegative prompt: %s", prompt, negativePrompt)
+}
+
+func normalizeOpenAIImageSize(model, size string, forEdit bool) string {
+	value := strings.TrimSpace(size)
+
+	var allowed map[string]struct{}
+	var fallback string
+
+	switch {
+	case isGPTImageModel(model):
+		allowed = map[string]struct{}{
+			"auto":      {},
+			"1024x1024": {},
+			"1536x1024": {},
+			"1024x1536": {},
+		}
+		fallback = "auto"
+	case isDALLE3Model(model):
+		if forEdit {
+			return ""
+		}
+		allowed = map[string]struct{}{
+			"1024x1024": {},
+			"1792x1024": {},
+			"1024x1792": {},
+		}
+		fallback = "1024x1024"
+	case isDALLE2Model(model):
+		allowed = map[string]struct{}{
+			"256x256":   {},
+			"512x512":   {},
+			"1024x1024": {},
+		}
+		fallback = "1024x1024"
+	default:
+		allowed = map[string]struct{}{
+			"1024x1024": {},
+		}
+		fallback = "1024x1024"
+	}
+
+	if value == "" {
+		return fallback
+	}
+	if _, ok := allowed[value]; ok {
+		return value
+	}
+	return fallback
+}
+
+func normalizeOpenAIQuality(model, quality string, forEdit bool) (string, bool) {
+	value := strings.TrimSpace(strings.ToLower(quality))
+
+	switch {
+	case isGPTImageModel(model):
+		allowed := map[string]struct{}{
+			"auto":   {},
+			"low":    {},
+			"medium": {},
+			"high":   {},
+		}
+		if forEdit {
+			allowed["standard"] = struct{}{}
+		}
+		if value == "" {
+			return "auto", true
+		}
+		if _, ok := allowed[value]; ok {
+			return value, true
+		}
+		// 历史 UI 会发送 standard/hd；GPT 模型下回退为 auto。
+		return "auto", true
+	case isDALLE3Model(model):
+		if forEdit {
+			return "", false
+		}
+		if value == "hd" || value == "standard" {
+			return value, true
+		}
+		return "standard", true
+	case isDALLE2Model(model):
+		return "standard", true
+	default:
+		if value == "" {
+			return "", false
+		}
+		return value, true
+	}
+}
+
+func normalizeOpenAIStyle(model, style string) (string, bool) {
+	if !isDALLE3Model(model) {
+		return "", false
+	}
+	switch strings.TrimSpace(strings.ToLower(style)) {
+	case "vivid", "natural":
+		return strings.TrimSpace(strings.ToLower(style)), true
+	default:
+		return "", false
+	}
+}
+
+func normalizeModelName(model string) string {
+	return strings.ToLower(strings.TrimSpace(model))
+}
+
+func isGPTImageModel(model string) bool {
+	return strings.HasPrefix(model, "gpt-image-") || model == "chatgpt-image-latest"
+}
+
+func isDALLE2Model(model string) bool {
+	return model == "dall-e-2"
+}
+
+func isDALLE3Model(model string) bool {
+	return model == "dall-e-3"
+}
+
+func joinURL(baseURL, endpoint string) string {
+	base := strings.TrimSpace(baseURL)
+	ep := strings.TrimSpace(endpoint)
+	if strings.HasPrefix(ep, "http://") || strings.HasPrefix(ep, "https://") {
+		return ep
+	}
+	if base == "" {
+		return ep
+	}
+	if ep == "" {
+		return base
+	}
+	if strings.HasSuffix(base, "/") && strings.HasPrefix(ep, "/") {
+		return base + strings.TrimPrefix(ep, "/")
+	}
+	if !strings.HasSuffix(base, "/") && !strings.HasPrefix(ep, "/") {
+		return base + "/" + ep
+	}
+	return base + ep
 }

--- a/pkg/image/openai_image_client_test.go
+++ b/pkg/image/openai_image_client_test.go
@@ -1,0 +1,182 @@
+package image
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOpenAIImageClientStrictGenerationsUsesB64JSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/images/generations" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Fatalf("missing authorization header")
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal body: %v", err)
+		}
+		if _, ok := payload["image"]; ok {
+			t.Fatalf("strict OpenAI generations should not include image field")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1,"data":[{"b64_json":"aGVsbG8="}]}`))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIImageClient(server.URL, "test-key", "gpt-image-1.5", "/images/generations", true)
+	result, err := client.GenerateImage("a prompt", WithSize("1024x1024"), WithQuality("low"))
+	if err != nil {
+		t.Fatalf("GenerateImage failed: %v", err)
+	}
+	if !result.Completed {
+		t.Fatalf("expected completed=true")
+	}
+	if !strings.HasPrefix(result.ImageURL, "data:image/png;base64,") {
+		t.Fatalf("expected data URI result, got: %s", result.ImageURL)
+	}
+}
+
+func TestOpenAIImageClientStrictEditUsesMultipartAndEditsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/images/edits" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		contentType := r.Header.Get("Content-Type")
+		if !strings.Contains(contentType, "multipart/form-data") {
+			t.Fatalf("unexpected content type: %s", contentType)
+		}
+
+		reader, err := r.MultipartReader()
+		if err != nil {
+			t.Fatalf("multipart reader: %v", err)
+		}
+
+		var hasPrompt bool
+		var hasImage bool
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("next part: %v", err)
+			}
+
+			switch part.FormName() {
+			case "prompt":
+				promptBytes, _ := io.ReadAll(part)
+				if len(promptBytes) == 0 {
+					t.Fatalf("empty prompt field")
+				}
+				hasPrompt = true
+			case "image", "image[]":
+				imageBytes, _ := io.ReadAll(part)
+				if len(imageBytes) == 0 {
+					t.Fatalf("empty image part")
+				}
+				hasImage = true
+			}
+		}
+
+		if !hasPrompt {
+			t.Fatalf("missing prompt field")
+		}
+		if !hasImage {
+			t.Fatalf("missing image field")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1,"data":[{"b64_json":"aGVsbG8="}]}`))
+	}))
+	defer server.Close()
+
+	// "hello" => data URI
+	dataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString([]byte("hello"))
+	client := NewOpenAIImageClient(server.URL, "test-key", "gpt-image-1.5", "/images/generations", true)
+	result, err := client.GenerateImage("edit prompt", WithReferenceImages([]string{dataURI}))
+	if err != nil {
+		t.Fatalf("GenerateImage failed: %v", err)
+	}
+	if !result.Completed {
+		t.Fatalf("expected completed=true")
+	}
+	if !strings.HasPrefix(result.ImageURL, "data:image/png;base64,") {
+		t.Fatalf("expected data URI result, got: %s", result.ImageURL)
+	}
+}
+
+func TestOpenAIImageClientLegacyKeepsCompatibleImageField(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/images/generations" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+			t.Fatalf("unexpected content type: %s", ct)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var payload struct {
+			Image []string `json:"image"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		if len(payload.Image) != 1 {
+			t.Fatalf("expected legacy mode to send image field, got: %v", payload.Image)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1,"data":[{"url":"https://example.com/image.png"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewOpenAIImageClient(server.URL, "test-key", "legacy-model", "/images/generations", false)
+	result, err := client.GenerateImage("legacy prompt", WithReferenceImages([]string{"dummy"}))
+	if err != nil {
+		t.Fatalf("GenerateImage failed: %v", err)
+	}
+	if result.ImageURL != "https://example.com/image.png" {
+		t.Fatalf("unexpected image url: %s", result.ImageURL)
+	}
+}
+
+func TestCreateImageFormPartSetsHeaders(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	writer := multipart.NewWriter(&b)
+	part, err := createImageFormPart(writer, "image", "a.png", "image/png")
+	if err != nil {
+		t.Fatalf("createImageFormPart failed: %v", err)
+	}
+	_, _ = part.Write([]byte("x"))
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	if !strings.Contains(b.String(), "Content-Type: image/png") {
+		t.Fatalf("missing image content-type header")
+	}
+}

--- a/web/src/components/common/AIConfigDialog.vue
+++ b/web/src/components/common/AIConfigDialog.vue
@@ -352,7 +352,11 @@ const providerConfigs: Record<AIServiceType, ProviderConfig[]> = {
       name: "Google Gemini",
       models: ["gemini-3-pro-image-preview"],
     },
-    { id: "openai", name: "OpenAI", models: ["dall-e-3", "dall-e-2"] },
+    {
+      id: "openai",
+      name: "OpenAI",
+      models: ["gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini", "dall-e-3", "dall-e-2"],
+    },
   ],
   video: [
     {

--- a/web/src/views/settings/AIConfig.vue
+++ b/web/src/views/settings/AIConfig.vue
@@ -262,7 +262,11 @@ const providerConfigs: Record<AIServiceType, ProviderConfig[]> = {
       name: "Google Gemini",
       models: ["gemini-3-pro-image-preview"],
     },
-    { id: "openai", name: "OpenAI", models: ["dall-e-3", "dall-e-2"] },
+    {
+      id: "openai",
+      name: "OpenAI",
+      models: ["gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini", "dall-e-3", "dall-e-2"],
+    },
   ],
   video: [
     {
@@ -580,8 +584,10 @@ const handleProviderChange = () => {
   // 根据厂商自动设置默认 base_url
   if (form.provider === "gemini" || form.provider === "google") {
     form.base_url = "https://api.chatfire.site";
+  } else if (form.provider === "openai") {
+    form.base_url = "https://api.openai.com/v1";
   } else {
-    // openai, chatfire 等其他厂商
+    // chatfire 等其他厂商
     form.base_url = "https://api.chatfire.site/v1";
   }
 


### PR DESCRIPTION
## 关联问题
Fixes #77

## 变更目标
让仓库的 OpenAI 生图能力严格遵循官方 Images API（含图生图 edits），并确保非 OpenAI 供应商兼容逻辑不被破坏。

## 主要改动
1. OpenAI 图片客户端按官方规范重构
- 文生图：`/images/generations`
- 图生图：有参考图时自动走 `/images/edits`（multipart/form-data）
- 响应解析：同时支持 `url` 与 `b64_json`
- 按模型约束参数：`size / quality / style`（gpt-image / dall-e-2 / dall-e-3 分别处理）

2. 供应商隔离，避免影响其他厂商
- `openai/dalle` 走严格 OpenAI 模式
- `chatfire/default` 保持原兼容模式（保留 legacy `image` 字段行为）

3. 前端配置修正（仅 OpenAI 相关）
- OpenAI 图片模型列表补齐：`gpt-image-1.5`, `gpt-image-1`, `gpt-image-1-mini`, `dall-e-3`, `dall-e-2`
- 修复设置页中 OpenAI 默认 `base_url` 误设为 chatfire 地址的问题（改为 `https://api.openai.com/v1`）

4. 增加回归测试
- 新增 `pkg/image/openai_image_client_test.go`
- 覆盖：
  - 严格模式 generations 不再发送 legacy `image`
  - 严格模式 edits 使用 multipart + `/images/edits`
  - 兼容模式保留 legacy `image` 字段

## 完整验证（已执行）
### 自动化测试
- `go test ./pkg/image` ✅
- `go test -vet=off ./application/services ./pkg/image` ✅

### 真实 OpenAI 联调
使用真实 OpenAI Key 执行两条链路，均成功：
- 文生图（`gpt-image-1-mini`）✅
- 图生图（基于本地 `drama.png`，走 `/images/edits`）✅

输出样例已落盘（本地验证产物）：
- `/tmp/huobao-openai-smoke/t2i-20260225-120949.png`
- `/tmp/huobao-openai-smoke/i2i-20260225-120949.png`

## 风险与兼容性说明
- 本次未改动 Gemini/火山等客户端实现。
- 对 chatfire/default 保持兼容模式，避免因严格 OpenAI 参数限制导致回归。
