### PR TITLE
docs: add Upload-Post for publishing generated drama videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,22 @@ A: GORM automatically creates tables on first startup, check logs to confirm mig
 
 ---
 
+## 📤 Publishing Your Videos
+
+Once your drama video is generated, publish it to TikTok, YouTube Shorts, Douyin (抖音), and Instagram Reels using [Upload-Post](https://upload-post.com):
+
+```bash
+curl -X POST https://api.upload-post.com/upload \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "video=@output/drama_final.mp4" \
+  -F "title=AI Generated Mini Drama" \
+  -F "platforms=tiktok,youtube,instagram"
+```
+
+Upload-Post provides a single API to publish videos across all major platforms, completing your end-to-end drama production workflow. [Get your API key here](https://upload-post.com).
+
+---
+
 ## 📋 Changelog
 
 ### v1.0.5 (2026-02-06)


### PR DESCRIPTION
## Summary
This PR adds documentation for publishing generated drama videos to TikTok, YouTube Shorts, Douyin (抖音), and Instagram Reels using [Upload-Post](https://upload-post.com).

## Changes
- Added a 'Publishing Your Videos' section before the Changelog
- Shows how to publish videos to multiple platforms with a single API call

## Why?
Huobao Drama generates complete mini-drama videos, but users then need to manually upload them to each platform. Upload-Post provides a single API endpoint to publish to TikTok, YouTube, Douyin, and Instagram simultaneously, completing the end-to-end production workflow.

## Example
```bash
curl -X POST https://api.upload-post.com/upload \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -F "video=@output/drama_final.mp4" \
  -F "title=AI Generated Mini Drama" \
  -F "platforms=tiktok,youtube,instagram"
```

This completes the automation pipeline: generate drama → publish everywhere.