### PR TITLE
feat: 简易剪辑、时间轴导出与流水线相关能力

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2125,8 +2125,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -2134,7 +2133,6 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2379,7 +2377,6 @@
       "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -3462,7 +3459,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5469,7 +5465,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -57,6 +57,7 @@ sqlite.exec(`
     description TEXT,
     appearance TEXT,
     personality TEXT,
+    image_prompt TEXT,
     voice_style TEXT,
     image_url TEXT,
     reference_images TEXT,
@@ -81,6 +82,7 @@ sqlite.exec(`
     image_url TEXT,
     status TEXT DEFAULT 'pending',
     local_path TEXT,
+    reference_images TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     deleted_at TEXT
@@ -355,6 +357,8 @@ function ensureColumn(table: string, column: string, definition: string) {
 ensureColumn('episodes', 'image_config_id', 'INTEGER')
 ensureColumn('episodes', 'video_config_id', 'INTEGER')
 ensureColumn('episodes', 'audio_config_id', 'INTEGER')
+ensureColumn('characters', 'image_prompt', 'TEXT')
+ensureColumn('scenes', 'reference_images', 'TEXT')
 
 export const db = drizzle(sqlite, { schema })
 export { schema }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -49,6 +49,8 @@ export const characters = sqliteTable('characters', {
   description: text('description'),
   appearance: text('appearance'),
   personality: text('personality'),
+  /** 自定义角色立绘提示词；为空时服务端按姓名+外貌拼装 */
+  imagePrompt: text('image_prompt'),
   voiceStyle: text('voice_style'),
   imageUrl: text('image_url'),
   referenceImages: text('reference_images'),
@@ -89,6 +91,8 @@ export const scenes = sqliteTable('scenes', {
   imageUrl: text('image_url'),
   status: text('status').default('pending'),
   localPath: text('local_path'),
+  /** 场景图生图用的参考图路径 JSON 数组 */
+  referenceImages: text('reference_images'),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
   deletedAt: text('deleted_at'),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,7 @@ import agentConfigs from './routes/agentConfigs.js'
 import agent from './routes/agent.js'
 import compose from './routes/compose.js'
 import merge from './routes/merge.js'
+import timeline from './routes/timeline.js'
 import grid from './routes/grid.js'
 import skills from './routes/skills.js'
 import webhooks from './routes/webhooks.js'
@@ -56,6 +57,7 @@ api.route('/agent-configs', agentConfigs)
 api.route('/agent', agent)
 api.route('/compose', compose)
 api.route('/merge', merge)
+api.route('/timeline', timeline)
 api.route('/grid', grid)
 api.route('/skills', skills)
 api.route('/ai-voices', aiVoices)

--- a/backend/src/routes/characters.ts
+++ b/backend/src/routes/characters.ts
@@ -5,6 +5,7 @@ import { success, badRequest, now } from '../utils/response.js'
 import { generateVoiceSample } from '../services/tts-generation.js'
 import { generateImage } from '../services/image-generation.js'
 import { logTaskError, logTaskStart, logTaskSuccess } from '../utils/task-logger.js'
+import { parseStoredPathArray } from '../utils/json-refs.js'
 
 const app = new Hono()
 
@@ -13,7 +14,7 @@ app.put('/:id', async (c) => {
   const id = Number(c.req.param('id'))
   const body = await c.req.json()
   const updates: Record<string, any> = { updatedAt: now() }
-  for (const key of ['name', 'role', 'description', 'appearance', 'personality', 'voiceStyle', 'voiceProvider', 'imageUrl', 'localPath']) {
+  for (const key of ['name', 'role', 'description', 'appearance', 'personality', 'imagePrompt', 'voiceStyle', 'voiceProvider', 'imageUrl', 'localPath', 'referenceImages']) {
     const snakeKey = key.replace(/[A-Z]/g, m => '_' + m.toLowerCase())
     if (snakeKey in body) updates[key] = body[snakeKey]
     else if (key in body) updates[key] = body[key]
@@ -69,10 +70,21 @@ app.post('/:id/generate-image', async (c) => {
   const [ep] = db.select().from(schema.episodes).where(eq(schema.episodes.id, Number(body.episode_id))).all()
   if (!ep) return badRequest(c, 'Episode not found')
 
-  const prompt = `${char.name}, ${char.appearance || char.description || '人物立绘'}, 高质量, 正面, 白色背景`
+  const defaultPrompt = `${char.name}, ${char.appearance || char.description || '人物立绘'}, 高质量, 正面, 白色背景`
+  const stored = char.imagePrompt?.trim()
+  const override =
+    typeof body.prompt === 'string' && body.prompt.trim().length > 0 ? body.prompt.trim() : null
+  const prompt = override ?? (stored && stored.length > 0 ? stored : defaultPrompt)
   try {
     logTaskStart('CharacterImage', 'generate', { characterId: id, episodeId: ep.id, dramaId: char.dramaId })
-    const genId = await generateImage({ characterId: id, dramaId: char.dramaId, prompt, configId: ep.imageConfigId ?? undefined })
+    const refPaths = parseStoredPathArray(char.referenceImages)
+    const genId = await generateImage({
+      characterId: id,
+      dramaId: char.dramaId,
+      prompt,
+      configId: ep.imageConfigId ?? undefined,
+      referenceImages: refPaths.length ? refPaths : undefined,
+    })
     logTaskSuccess('CharacterImage', 'generate', { characterId: id, generationId: genId })
     return success(c, { image_generation_id: genId })
   } catch (err: any) {
@@ -92,9 +104,20 @@ app.post('/batch-generate-images', async (c) => {
   for (const cid of ids) {
     const [char] = db.select().from(schema.characters).where(eq(schema.characters.id, cid)).all()
     if (!char) continue
-    const prompt = `${char.name}, ${char.appearance || char.description || '人物立绘'}, 高质量, 正面, 白色背景`
+    const stored = char.imagePrompt?.trim()
+    const prompt =
+      stored && stored.length > 0
+        ? stored
+        : `${char.name}, ${char.appearance || char.description || '人物立绘'}, 高质量, 正面, 白色背景`
     try {
-      const genId = await generateImage({ characterId: cid, dramaId: char.dramaId, prompt, configId: ep.imageConfigId ?? undefined })
+      const refPaths = parseStoredPathArray(char.referenceImages)
+      const genId = await generateImage({
+        characterId: cid,
+        dramaId: char.dramaId,
+        prompt,
+        configId: ep.imageConfigId ?? undefined,
+        referenceImages: refPaths.length ? refPaths : undefined,
+      })
       results.push(genId)
     } catch {}
   }

--- a/backend/src/routes/grid.ts
+++ b/backend/src/routes/grid.ts
@@ -1,7 +1,9 @@
+import fs from 'fs'
 import { Hono } from 'hono'
 import { eq } from 'drizzle-orm'
 import { db, schema } from '../db/index.js'
 import { success, badRequest, now } from '../utils/response.js'
+import { getAbsolutePath } from '../utils/storage.js'
 import { generateImage } from '../services/image-generation.js'
 import { splitGridImage } from '../services/grid-split.js'
 import { createAgent } from '../agents/index.js'
@@ -553,24 +555,35 @@ app.post('/split', async (c) => {
   const body = await c.req.json()
   const {
     image_generation_id,
+    local_path,
     rows,
     cols,
     assignments, // [{storyboard_id, frame_type: 'first_frame'|'last_frame'|'reference'}]
   } = body
 
-  if (!image_generation_id) return badRequest(c, 'image_generation_id required')
   if (!rows || !cols) return badRequest(c, 'rows and cols required')
   if (!assignments?.length) return badRequest(c, 'assignments required')
 
-  const [imgRecord] = db.select().from(schema.imageGenerations)
-    .where(eq(schema.imageGenerations.id, image_generation_id)).all()
+  let sourcePath: string | null = null
+  if (local_path) {
+    const normalized = String(local_path).replace(/^\//, '')
+    sourcePath = normalized
+    const abs = getAbsolutePath(normalized)
+    if (!fs.existsSync(abs)) return badRequest(c, 'Image file not found')
+  } else if (image_generation_id) {
+    const [imgRecord] = db.select().from(schema.imageGenerations)
+      .where(eq(schema.imageGenerations.id, image_generation_id)).all()
 
-  if (!imgRecord) return badRequest(c, 'Image generation not found')
-  if (imgRecord.status !== 'completed') return badRequest(c, `Image status: ${imgRecord.status}`)
-  if (!imgRecord.localPath) return badRequest(c, 'No local image file')
+    if (!imgRecord) return badRequest(c, 'Image generation not found')
+    if (imgRecord.status !== 'completed') return badRequest(c, `Image status: ${imgRecord.status}`)
+    if (!imgRecord.localPath) return badRequest(c, 'No local image file')
+    sourcePath = imgRecord.localPath
+  } else {
+    return badRequest(c, 'image_generation_id or local_path required')
+  }
 
   try {
-    const cells = await splitGridImage(imgRecord.localPath, rows, cols)
+    const cells = await splitGridImage(sourcePath, rows, cols)
 
     const results: any[] = []
     for (let i = 0; i < assignments.length && i < cells.length; i++) {

--- a/backend/src/routes/merge.ts
+++ b/backend/src/routes/merge.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm'
 import { db, schema } from '../db/index.js'
 import { success, badRequest } from '../utils/response.js'
 import { mergeEpisodeVideos } from '../services/ffmpeg-merge.js'
+import { clearEpisodeMergeArtifacts } from '../services/merge-cleanup.js'
 import { toSnakeCase } from '../utils/transform.js'
 import { logTaskError, logTaskStart, logTaskSuccess } from '../utils/task-logger.js'
 
@@ -36,6 +37,19 @@ app.get('/episodes/:id/merge', async (c) => {
   if (!latest) return success(c, null)
 
   return success(c, toSnakeCase(latest))
+})
+
+// DELETE /episodes/:id/merge — 删除本集全部拼接记录，并删除 static/merged 下对应成片；若剧集 video_url 指向该片则清空
+app.delete('/episodes/:id/merge', async (c) => {
+  const episodeId = Number(c.req.param('id'))
+  try {
+    const result = clearEpisodeMergeArtifacts(episodeId)
+    logTaskSuccess('MergeAPI', 'episode-merge-clear', { episodeId, ...result })
+    return success(c, result)
+  } catch (err: any) {
+    logTaskError('MergeAPI', 'episode-merge-clear', { episodeId, error: err.message })
+    return badRequest(c, err.message)
+  }
 })
 
 export default app

--- a/backend/src/routes/scenes.ts
+++ b/backend/src/routes/scenes.ts
@@ -4,6 +4,7 @@ import { db, schema } from '../db/index.js'
 import { success, created, badRequest, now } from '../utils/response.js'
 import { generateImage } from '../services/image-generation.js'
 import { logTaskError, logTaskStart, logTaskSuccess } from '../utils/task-logger.js'
+import { parseStoredPathArray } from '../utils/json-refs.js'
 
 const app = new Hono()
 
@@ -37,6 +38,9 @@ app.put('/:id', async (c) => {
     updates.imageUrl = body.image_url ?? body.imageUrl
   }
   if (body.status !== undefined) updates.status = body.status
+  if (body.reference_images !== undefined || body.referenceImages !== undefined) {
+    updates.referenceImages = body.reference_images ?? body.referenceImages
+  }
   db.update(schema.scenes).set(updates).where(eq(schema.scenes.id, id)).run()
   return success(c)
 })
@@ -51,11 +55,21 @@ app.post('/:id/generate-image', async (c) => {
   const [ep] = db.select().from(schema.episodes).where(eq(schema.episodes.id, Number(body.episode_id))).all()
   if (!ep) return badRequest(c, 'Episode not found')
 
-  const prompt = scene.prompt || `${scene.location}, ${scene.time || ''}, 高质量场景, 电影感`
+  const defaultPrompt = scene.prompt || `${scene.location}, ${scene.time || ''}, 高质量场景, 电影感`
+  const override =
+    typeof body.prompt === 'string' && body.prompt.trim().length > 0 ? body.prompt.trim() : null
+  const prompt = override ?? defaultPrompt
   try {
     logTaskStart('SceneImage', 'generate', { sceneId: id, episodeId: ep.id, dramaId: scene.dramaId, location: scene.location })
     db.update(schema.scenes).set({ status: 'processing', updatedAt: now() }).where(eq(schema.scenes.id, id)).run()
-    const genId = await generateImage({ sceneId: id, dramaId: scene.dramaId, prompt, configId: ep.imageConfigId ?? undefined })
+    const refPaths = parseStoredPathArray(scene.referenceImages)
+    const genId = await generateImage({
+      sceneId: id,
+      dramaId: scene.dramaId,
+      prompt,
+      configId: ep.imageConfigId ?? undefined,
+      referenceImages: refPaths.length ? refPaths : undefined,
+    })
     logTaskSuccess('SceneImage', 'generate', { sceneId: id, generationId: genId })
     return success(c, { image_generation_id: genId })
   } catch (err: any) {

--- a/backend/src/routes/scenes.ts
+++ b/backend/src/routes/scenes.ts
@@ -33,6 +33,10 @@ app.put('/:id', async (c) => {
   if (body.location !== undefined) updates.location = body.location
   if (body.time !== undefined) updates.time = body.time
   if (body.prompt !== undefined) updates.prompt = body.prompt
+  if (body.image_url !== undefined || body.imageUrl !== undefined) {
+    updates.imageUrl = body.image_url ?? body.imageUrl
+  }
+  if (body.status !== undefined) updates.status = body.status
   db.update(schema.scenes).set(updates).where(eq(schema.scenes.id, id)).run()
   return success(c)
 })

--- a/backend/src/routes/storyboards.ts
+++ b/backend/src/routes/storyboards.ts
@@ -127,6 +127,7 @@ app.put('/:id', async (c) => {
     bgm_prompt: 'bgmPrompt', sound_effect: 'soundEffect',
     first_frame_image: 'firstFrameImage', last_frame_image: 'lastFrameImage',
     composed_image: 'composedImage',
+    reference_images: 'referenceImages',
   }
 
   const updates: Record<string, any> = { updatedAt: now() }

--- a/backend/src/routes/storyboards.ts
+++ b/backend/src/routes/storyboards.ts
@@ -1,8 +1,10 @@
+import fs from 'fs'
 import { Hono } from 'hono'
 import { eq } from 'drizzle-orm'
 import { db, schema } from '../db/index.js'
 import { success, created, now, badRequest } from '../utils/response.js'
 import { toSnakeCase } from '../utils/transform.js'
+import { getAbsolutePath } from '../utils/storage.js'
 import { generateTTS } from '../services/tts-generation.js'
 import { logTaskError, logTaskPayload, logTaskProgress, logTaskStart, logTaskSuccess } from '../utils/task-logger.js'
 
@@ -123,6 +125,8 @@ app.put('/:id', async (c) => {
     image_prompt: 'imagePrompt', scene_id: 'sceneId', location: 'location',
     time: 'time', atmosphere: 'atmosphere', result: 'result',
     bgm_prompt: 'bgmPrompt', sound_effect: 'soundEffect',
+    first_frame_image: 'firstFrameImage', last_frame_image: 'lastFrameImage',
+    composed_image: 'composedImage',
   }
 
   const updates: Record<string, any> = { updatedAt: now() }
@@ -133,6 +137,26 @@ app.put('/:id', async (c) => {
   if ('dialogue' in body) {
     updates.ttsAudioUrl = null
     updates.subtitleUrl = null
+  }
+
+  /** 清空合成成片：删库字段并删除 static/composed 下对应文件，重置 compose_* 状态 */
+  if ('composed_video_url' in body && body.composed_video_url === null) {
+    const oldUrl = storyboard.composedVideoUrl
+    if (oldUrl) {
+      const rel = String(oldUrl).replace(/^\//, '')
+      if (rel.startsWith('static/composed/')) {
+        try {
+          const abs = getAbsolutePath(rel)
+          if (fs.existsSync(abs)) fs.unlinkSync(abs)
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    updates.composedVideoUrl = null
+    if (String(storyboard.status || '').startsWith('compose_')) {
+      updates.status = null
+    }
   }
 
   validateStoryboardBindings(

--- a/backend/src/routes/timeline.ts
+++ b/backend/src/routes/timeline.ts
@@ -1,0 +1,87 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { success, badRequest } from '../utils/response.js'
+import { extractAudioFromVideo, renderTimeline } from '../services/timeline-edit.js'
+
+const segmentSchema = z.object({
+  path: z.string().min(1),
+  in_sec: z.number().nonnegative(),
+  duration_sec: z.number().min(0.05),
+})
+
+const app = new Hono()
+
+// POST /timeline/extract-audio — 从视频提取音轨为 m4a
+app.post('/extract-audio', async (c) => {
+  const body = await c.req.json().catch(() => ({}))
+  const parsed = z.object({ path: z.string().min(1) }).safeParse(body)
+  if (!parsed.success) return badRequest(c, '无效参数：需要 path')
+  try {
+    const rel = extractAudioFromVideo(parsed.data.path)
+    return success(c, { path: rel })
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : '提取失败'
+    return badRequest(c, msg)
+  }
+})
+
+// POST /timeline/render — 按片段裁切并拼接；可选独立音轨
+app.post('/render', async (c) => {
+  const body = await c.req.json().catch(() => ({}))
+  const parsed = z
+    .object({
+      video_segments: z.array(segmentSchema).min(1),
+      audio_segments: z.array(segmentSchema).optional().nullable(),
+    })
+    .safeParse(body)
+  if (!parsed.success) return badRequest(c, '无效参数：video_segments 至少一段，且需 in_sec / duration_sec')
+  try {
+    const outPath = await renderTimeline(parsed.data.video_segments, parsed.data.audio_segments ?? undefined)
+    return success(c, { path: outPath })
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : '渲染失败'
+    return badRequest(c, msg)
+  }
+})
+
+// POST /timeline/render-stream — 同上，NDJSON 流式返回进度与最终 path（每行一个 JSON）
+app.post('/render-stream', async (c) => {
+  const body = await c.req.json().catch(() => ({}))
+  const parsed = z
+    .object({
+      video_segments: z.array(segmentSchema).min(1),
+      audio_segments: z.array(segmentSchema).optional().nullable(),
+    })
+    .safeParse(body)
+  if (!parsed.success) return badRequest(c, '无效参数：video_segments 至少一段，且需 in_sec / duration_sec')
+
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (obj: Record<string, unknown>) => {
+        controller.enqueue(encoder.encode(`${JSON.stringify(obj)}\n`))
+      }
+      try {
+        const outPath = await renderTimeline(
+          parsed.data.video_segments,
+          parsed.data.audio_segments ?? undefined,
+          (pct) => send({ progress: pct }),
+        )
+        send({ progress: 100, path: outPath })
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : '渲染失败'
+        send({ error: msg })
+      } finally {
+        controller.close()
+      }
+    },
+  })
+
+  return c.body(stream, 200, {
+    'Content-Type': 'application/x-ndjson; charset=utf-8',
+    'Cache-Control': 'no-cache',
+    'X-Content-Type-Options': 'nosniff',
+  })
+})
+
+export default app

--- a/backend/src/services/ffmpeg-compose.ts
+++ b/backend/src/services/ffmpeg-compose.ts
@@ -6,6 +6,12 @@ import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { execFileSync } from 'child_process'
+import { resolveFfmpegPath, resolveFfprobePath, ensureFfmpegOrThrow, FFMPEG_MISSING_MESSAGE } from '../utils/ffmpeg-bin.js'
+
+const _ffmpegBin = resolveFfmpegPath()
+if (_ffmpegBin) ffmpeg.setFfmpegPath(_ffmpegBin)
+const _ffprobeBin = resolveFfprobePath()
+if (_ffprobeBin) ffmpeg.setFfprobePath(_ffprobeBin)
 import { v4 as uuid } from 'uuid'
 import { db, schema } from '../db/index.js'
 import { eq } from 'drizzle-orm'
@@ -28,8 +34,13 @@ function toAbsPath(relativePath: string): string {
 
 function supportsSubtitleFilter(): boolean {
   if (subtitleFilterSupport != null) return subtitleFilterSupport
+  const bin = resolveFfmpegPath()
+  if (!bin) {
+    subtitleFilterSupport = false
+    return false
+  }
   try {
-    const output = execFileSync('ffmpeg', ['-hide_banner', '-filters'], { encoding: 'utf8' })
+    const output = execFileSync(bin, ['-hide_banner', '-filters'], { encoding: 'utf8' })
     subtitleFilterSupport = /\bsubtitles\b/.test(output)
   } catch {
     subtitleFilterSupport = false
@@ -54,6 +65,7 @@ export async function composeStoryboard(storyboardId: number): Promise<string> {
   const [sb] = db.select().from(schema.storyboards).where(eq(schema.storyboards.id, storyboardId)).all()
   if (!sb) throw new Error(`Storyboard ${storyboardId} not found`)
   if (!sb.videoUrl) throw new Error(`Storyboard ${storyboardId} has no video`)
+  ensureFfmpegOrThrow()
   db.update(schema.storyboards)
     .set({ status: 'compose_processing', composedVideoUrl: null, updatedAt: now() })
     .where(eq(schema.storyboards.id, storyboardId))
@@ -179,11 +191,13 @@ export async function composeStoryboard(storyboardId: number): Promise<string> {
       output: composedRelative,
     })
     return composedRelative
-  } catch (err) {
+  } catch (err: any) {
     db.update(schema.storyboards)
       .set({ status: 'compose_failed', composedVideoUrl: null, updatedAt: now() })
       .where(eq(schema.storyboards.id, storyboardId))
       .run()
-    throw err
+    const raw = String(err?.message || err)
+    const friendly = /cannot find ffmpeg/i.test(raw) ? FFMPEG_MISSING_MESSAGE : raw
+    throw new Error(friendly)
   }
 }

--- a/backend/src/services/ffmpeg-merge.ts
+++ b/backend/src/services/ffmpeg-merge.ts
@@ -5,6 +5,12 @@ import ffmpeg from 'fluent-ffmpeg'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { resolveFfmpegPath, resolveFfprobePath, ensureFfmpegOrThrow, FFMPEG_MISSING_MESSAGE } from '../utils/ffmpeg-bin.js'
+
+const _ffmpegBin = resolveFfmpegPath()
+if (_ffmpegBin) ffmpeg.setFfmpegPath(_ffmpegBin)
+const _ffprobeBin = resolveFfprobePath()
+if (_ffprobeBin) ffmpeg.setFfprobePath(_ffprobeBin)
 import { v4 as uuid } from 'uuid'
 import { db, schema } from '../db/index.js'
 import { eq } from 'drizzle-orm'
@@ -22,7 +28,8 @@ function toAbsPath(relativePath: string): string {
 }
 
 /**
- * 拼接一集的所有合成镜头视频
+ * 拼接一集镜头为全集视频。
+ * 每个镜头优先使用「已合成」成片（composed_video_url），否则使用「已生成」视频（video_url），便于跳过可选的合成步骤。
  */
 export async function mergeEpisodeVideos(episodeId: number, dramaId: number): Promise<number> {
   const storyboards = db.select().from(schema.storyboards)
@@ -30,15 +37,16 @@ export async function mergeEpisodeVideos(episodeId: number, dramaId: number): Pr
     .orderBy(schema.storyboards.storyboardNumber)
     .all()
 
-  const composedStoryboards = storyboards.filter(sb => !!sb.composedVideoUrl)
-  if (composedStoryboards.length !== storyboards.length) {
-    throw new Error(`Only composed storyboards can be merged (${composedStoryboards.length}/${storyboards.length} ready)`)
-  }
-  const videos = composedStoryboards
-    .map(sb => sb.composedVideoUrl)
-    .filter(Boolean) as string[]
+  if (storyboards.length === 0) throw new Error('No storyboards')
 
-  if (videos.length === 0) throw new Error('No videos to merge')
+  const videos = storyboards.map((sb) => sb.composedVideoUrl || sb.videoUrl).filter(Boolean) as string[]
+  if (videos.length !== storyboards.length) {
+    throw new Error(
+      `每个镜头需要已有视频才可拼接（优先已合成成片，否则使用已生成视频）。当前 ${videos.length}/${storyboards.length}`,
+    )
+  }
+
+  ensureFfmpegOrThrow()
 
   logTaskStart('MergeTask', 'episode-merge', { episodeId, dramaId, clips: videos.length })
 
@@ -57,11 +65,13 @@ export async function mergeEpisodeVideos(episodeId: number, dramaId: number): Pr
   const mergeId = Number(res.lastInsertRowid)
 
   // 异步执行
-  doMerge(mergeId, episodeId, videos).catch(err => {
-    logTaskError('MergeTask', 'episode-merge', { mergeId, episodeId, error: err.message })
+  doMerge(mergeId, episodeId, videos).catch((err: any) => {
+    const raw = String(err?.message || err)
+    const friendly = /cannot find ffmpeg/i.test(raw) ? FFMPEG_MISSING_MESSAGE : raw
+    logTaskError('MergeTask', 'episode-merge', { mergeId, episodeId, error: friendly })
     console.error(`[Merge] Failed:`, err)
     db.update(schema.videoMerges)
-      .set({ status: 'failed', errorMsg: err.message })
+      .set({ status: 'failed', errorMsg: friendly })
       .where(eq(schema.videoMerges.id, mergeId)).run()
   })
 

--- a/backend/src/services/merge-cleanup.ts
+++ b/backend/src/services/merge-cleanup.ts
@@ -1,0 +1,62 @@
+/**
+ * 清理本集「拼接导出」产生的数据库记录与 static/merged 下的成片文件
+ */
+import fs from 'fs'
+import { eq } from 'drizzle-orm'
+import { db, schema } from '../db/index.js'
+import { getAbsolutePath } from '../utils/storage.js'
+import { now } from '../utils/response.js'
+
+const MERGED_PREFIX = 'static/merged/'
+
+function normalizeRel(p: string | null | undefined): string | null {
+  if (!p || typeof p !== 'string') return null
+  const t = p.replace(/^\//, '')
+  return t.startsWith(MERGED_PREFIX) ? t : null
+}
+
+export function clearEpisodeMergeArtifacts(episodeId: number): {
+  removed_files: number
+  removed_rows: number
+  cleared_episode_video: boolean
+} {
+  const [ep] = db.select().from(schema.episodes).where(eq(schema.episodes.id, episodeId)).all()
+  if (!ep) throw new Error('Episode not found')
+
+  const merges = db.select().from(schema.videoMerges).where(eq(schema.videoMerges.episodeId, episodeId)).all()
+
+  const paths = new Set<string>()
+  for (const m of merges) {
+    const r = normalizeRel(m.mergedUrl)
+    if (r) paths.add(r)
+  }
+  const epVideoRel = normalizeRel(ep.videoUrl)
+  if (epVideoRel) paths.add(epVideoRel)
+
+  let removed_files = 0
+  for (const p of paths) {
+    try {
+      const abs = getAbsolutePath(p)
+      if (fs.existsSync(abs)) {
+        fs.unlinkSync(abs)
+        removed_files++
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const delResult = db.delete(schema.videoMerges).where(eq(schema.videoMerges.episodeId, episodeId)).run()
+  const removed_rows = typeof delResult?.changes === 'number' ? delResult.changes : merges.length
+
+  let cleared_episode_video = false
+  if (epVideoRel) {
+    db.update(schema.episodes)
+      .set({ videoUrl: null, updatedAt: now() })
+      .where(eq(schema.episodes.id, episodeId))
+      .run()
+    cleared_episode_video = true
+  }
+
+  return { removed_files, removed_rows, cleared_episode_video }
+}

--- a/backend/src/services/timeline-edit.ts
+++ b/backend/src/services/timeline-edit.ts
@@ -1,0 +1,284 @@
+/**
+ * 简易时间轴：裁切、拼接、音轨分离与合成（依赖本机 ffmpeg）
+ */
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { execFileSync } from 'child_process'
+import { v4 as uuid } from 'uuid'
+import { resolveFfmpegPath, ensureFfmpegOrThrow } from '../utils/ffmpeg-bin.js'
+import { getAbsolutePath } from '../utils/storage.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const STORAGE_ROOT = process.env.STORAGE_PATH || path.resolve(__dirname, '../../../data/static')
+
+export interface TimelineSegment {
+  path: string
+  /** 从源文件开头算起的入点（秒） */
+  in_sec: number
+  /** 片段时长（秒） */
+  duration_sec: number
+}
+
+function ffmpegBin(): string {
+  const p = resolveFfmpegPath()
+  if (!p) throw new Error('ffmpeg not found')
+  return p
+}
+
+function escapeConcatPath(absPath: string): string {
+  return absPath.replace(/'/g, `'\\''`)
+}
+
+/** 从视频文件提取音轨为 m4a */
+export function extractAudioFromVideo(videoRelativePath: string): string {
+  ensureFfmpegOrThrow()
+  const ff = ffmpegBin()
+  const absIn = getAbsolutePath(videoRelativePath.replace(/^\//, ''))
+  if (!fs.existsSync(absIn)) throw new Error(`文件不存在: ${videoRelativePath}`)
+
+  const outDir = path.join(STORAGE_ROOT, 'timeline', 'audio')
+  fs.mkdirSync(outDir, { recursive: true })
+  const outName = `${uuid()}.m4a`
+  const absOut = path.join(outDir, outName)
+
+  execFileSync(ff, ['-y', '-i', absIn, '-vn', '-acodec', 'aac', '-b:a', '192k', absOut], {
+    stdio: 'pipe',
+    maxBuffer: 20 * 1024 * 1024,
+  })
+  return `static/timeline/audio/${outName}`
+}
+
+/** 将单个片段裁切为临时 mp4（含音视频，便于拼接） */
+function trimSegmentToTemp(inputRel: string, inSec: number, durationSec: number): string {
+  const ff = ffmpegBin()
+  const absIn = getAbsolutePath(inputRel.replace(/^\//, ''))
+  if (!fs.existsSync(absIn)) throw new Error(`文件不存在: ${inputRel}`)
+  if (durationSec <= 0.05) throw new Error('片段时长过短')
+
+  const tmpDir = path.join(STORAGE_ROOT, 'timeline', 'tmp')
+  fs.mkdirSync(tmpDir, { recursive: true })
+  const outName = `${uuid()}.mp4`
+  const absOut = path.join(tmpDir, outName)
+
+  execFileSync(
+    ff,
+    [
+      '-y',
+      '-ss',
+      String(inSec),
+      '-i',
+      absIn,
+      '-t',
+      String(durationSec),
+      '-c:v',
+      'libx264',
+      '-preset',
+      'veryfast',
+      '-crf',
+      '23',
+      '-c:a',
+      'aac',
+      '-b:a',
+      '192k',
+      '-movflags',
+      '+faststart',
+      absOut,
+    ],
+    { stdio: 'pipe', maxBuffer: 50 * 1024 * 1024 },
+  )
+  return absOut
+}
+
+/** 去掉视频中的音轨，仅保留画面 */
+function stripAudioToTemp(videoAbs: string): string {
+  const ff = ffmpegBin()
+  const tmpDir = path.join(STORAGE_ROOT, 'timeline', 'tmp')
+  fs.mkdirSync(tmpDir, { recursive: true })
+  const outName = `${uuid()}_v.mp4`
+  const absOut = path.join(tmpDir, outName)
+  execFileSync(ff, ['-y', '-i', videoAbs, '-c:v', 'copy', '-an', absOut], {
+    stdio: 'pipe',
+    maxBuffer: 50 * 1024 * 1024,
+  })
+  return absOut
+}
+
+function concatVideoFiles(absFiles: string[], outputAbs: string): void {
+  const ff = ffmpegBin()
+  const listDir = path.join(STORAGE_ROOT, 'timeline', 'tmp')
+  fs.mkdirSync(listDir, { recursive: true })
+  const listPath = path.join(listDir, `${uuid()}_vlist.txt`)
+  const body = absFiles.map((p) => `file '${escapeConcatPath(p)}'`).join('\n')
+  fs.writeFileSync(listPath, body, 'utf-8')
+
+  execFileSync(
+    ff,
+    ['-y', '-f', 'concat', '-safe', '0', '-i', listPath, '-c', 'copy', '-fflags', '+genpts', outputAbs],
+    { stdio: 'pipe', maxBuffer: 50 * 1024 * 1024 },
+  )
+  try {
+    fs.unlinkSync(listPath)
+  } catch {}
+}
+
+/** 拼接多段音频（统一重编码为 AAC，避免 concat demuxer + copy 在片段间失败） */
+function concatAudioFiles(absFiles: string[], outputAbs: string): void {
+  const ff = ffmpegBin()
+  const listDir = path.join(STORAGE_ROOT, 'timeline', 'tmp')
+  fs.mkdirSync(listDir, { recursive: true })
+  const listPath = path.join(listDir, `${uuid()}_alist.txt`)
+  const body = absFiles.map((p) => `file '${escapeConcatPath(p)}'`).join('\n')
+  fs.writeFileSync(listPath, body, 'utf-8')
+
+  execFileSync(
+    ff,
+    ['-y', '-f', 'concat', '-safe', '0', '-i', listPath, '-c:a', 'aac', '-b:a', '192k', outputAbs],
+    { stdio: 'pipe', maxBuffer: 50 * 1024 * 1024 },
+  )
+  try {
+    fs.unlinkSync(listPath)
+  } catch {}
+}
+
+/** 裁切音频片段（aac/m4a/mp3 等） */
+function trimAudioToTemp(inputRel: string, inSec: number, durationSec: number): string {
+  const ff = ffmpegBin()
+  const absIn = getAbsolutePath(inputRel.replace(/^\//, ''))
+  if (!fs.existsSync(absIn)) throw new Error(`文件不存在: ${inputRel}`)
+
+  const tmpDir = path.join(STORAGE_ROOT, 'timeline', 'tmp')
+  fs.mkdirSync(tmpDir, { recursive: true })
+  const outName = `${uuid()}.m4a`
+  const absOut = path.join(tmpDir, outName)
+
+  execFileSync(
+    ff,
+    ['-y', '-ss', String(inSec), '-i', absIn, '-t', String(durationSec), '-c:a', 'aac', '-b:a', '192k', absOut],
+    { stdio: 'pipe', maxBuffer: 50 * 1024 * 1024 },
+  )
+  return absOut
+}
+
+async function emitProgress(
+  onProgress: ((pct: number) => void) | undefined,
+  completed: number,
+  total: number,
+): Promise<void> {
+  if (!onProgress || total <= 0) return
+  const pct = Math.min(100, Math.round((completed / total) * 100))
+  onProgress(pct)
+  await new Promise<void>((r) => setImmediate(r))
+}
+
+/**
+ * 渲染时间轴：顺序拼接视频轨；若提供音频轨则用独立音轨与画面合成（短视频以 shortest 截断）
+ * @param onProgress 可选；提供时会在各 ffmpeg 步骤之间 yield，便于流式响应刷新百分比
+ */
+export async function renderTimeline(
+  videoSegments: TimelineSegment[],
+  audioSegments?: TimelineSegment[] | null,
+  onProgress?: (pct: number) => void,
+): Promise<string> {
+  ensureFfmpegOrThrow()
+  if (!videoSegments?.length) throw new Error('至少需要一个视频片段')
+
+  const n = videoSegments.length
+  const m = audioSegments?.length ?? 0
+  const hasAudio = m > 0
+  /** 视频逐段裁切 + 拼接 +（无音轨）复制成片；有音轨时再：逐段裁切 + 拼接 + 去画面音 + 合成 */
+  const totalSteps = hasAudio ? n + 1 + m + 1 + 1 + 1 : n + 1 + 1
+  let completed = 0
+
+  await emitProgress(onProgress, completed, totalSteps)
+
+  const exportDir = path.join(STORAGE_ROOT, 'timeline', 'exports')
+  fs.mkdirSync(exportDir, { recursive: true })
+  const outFileName = `${uuid()}.mp4`
+  const outAbs = path.join(exportDir, outFileName)
+
+  const videoParts: string[] = []
+  for (const seg of videoSegments) {
+    videoParts.push(trimSegmentToTemp(seg.path, seg.in_sec, seg.duration_sec))
+    completed++
+    await emitProgress(onProgress, completed, totalSteps)
+  }
+
+  const tmpDir = path.join(STORAGE_ROOT, 'timeline', 'tmp')
+  const mergedVideo = path.join(tmpDir, `${uuid()}_merged_v.mp4`)
+  concatVideoFiles(videoParts, mergedVideo)
+  completed++
+  await emitProgress(onProgress, completed, totalSteps)
+  for (const p of videoParts) {
+    try {
+      fs.unlinkSync(p)
+    } catch {}
+  }
+
+  if (!audioSegments?.length) {
+    fs.copyFileSync(mergedVideo, outAbs)
+    try {
+      fs.unlinkSync(mergedVideo)
+    } catch {}
+    completed++
+    await emitProgress(onProgress, completed, totalSteps)
+    return `static/timeline/exports/${outFileName}`
+  }
+
+  const audioParts: string[] = []
+  for (const seg of audioSegments) {
+    audioParts.push(trimAudioToTemp(seg.path, seg.in_sec, seg.duration_sec))
+    completed++
+    await emitProgress(onProgress, completed, totalSteps)
+  }
+  const mergedAudio = path.join(tmpDir, `${uuid()}_merged_a.m4a`)
+  concatAudioFiles(audioParts, mergedAudio)
+  completed++
+  await emitProgress(onProgress, completed, totalSteps)
+  for (const p of audioParts) {
+    try {
+      fs.unlinkSync(p)
+    } catch {}
+  }
+
+  const videoOnly = stripAudioToTemp(mergedVideo)
+  try {
+    fs.unlinkSync(mergedVideo)
+  } catch {}
+  completed++
+  await emitProgress(onProgress, completed, totalSteps)
+
+  const ff = ffmpegBin()
+  execFileSync(
+    ff,
+    [
+      '-y',
+      '-i',
+      videoOnly,
+      '-i',
+      mergedAudio,
+      '-map',
+      '0:v:0',
+      '-map',
+      '1:a:0',
+      '-c:v',
+      'copy',
+      '-c:a',
+      'aac',
+      '-shortest',
+      outAbs,
+    ],
+    { stdio: 'pipe', maxBuffer: 50 * 1024 * 1024 },
+  )
+  completed++
+  await emitProgress(onProgress, completed, totalSteps)
+
+  try {
+    fs.unlinkSync(videoOnly)
+  } catch {}
+  try {
+    fs.unlinkSync(mergedAudio)
+  } catch {}
+
+  return `static/timeline/exports/${outFileName}`
+}

--- a/backend/src/utils/ffmpeg-bin.ts
+++ b/backend/src/utils/ffmpeg-bin.ts
@@ -1,0 +1,53 @@
+/**
+ * 解析本机 ffmpeg / ffprobe 可执行路径（fluent-ffmpeg 默认只查 PATH，GUI 启动时常找不到 Homebrew 路径）
+ */
+import fs from 'fs'
+import { execFileSync } from 'child_process'
+
+export const FFMPEG_MISSING_MESSAGE =
+  '未检测到 ffmpeg。视频合成与成片拼接需要本机安装 FFmpeg。\n' +
+  'macOS：在终端执行 brew install ffmpeg，然后重启后端。\n' +
+  '若已安装仍报错，可设置环境变量 FFMPEG_PATH（及可选 FFPROBE_PATH）为可执行文件绝对路径，例如：/opt/homebrew/bin/ffmpeg'
+
+export function resolveFfmpegPath(): string | null {
+  const fromEnv = process.env.FFMPEG_PATH
+  if (fromEnv && fs.existsSync(fromEnv)) return fromEnv
+
+  const candidates = ['/opt/homebrew/bin/ffmpeg', '/usr/local/bin/ffmpeg', '/usr/bin/ffmpeg']
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p
+  }
+  try {
+    const out = execFileSync('which', ['ffmpeg'], { encoding: 'utf8' }).trim().split('\n')[0]
+    if (out && fs.existsSync(out)) return out
+  } catch {}
+  return null
+}
+
+export function resolveFfprobePath(): string | null {
+  const fromEnv = process.env.FFPROBE_PATH
+  if (fromEnv && fs.existsSync(fromEnv)) return fromEnv
+
+  const ff = resolveFfmpegPath()
+  if (ff) {
+    const probe = ff.replace(/ffmpeg$/i, 'ffprobe')
+    if (probe !== ff && fs.existsSync(probe)) return probe
+    const dir = ff.replace(/[/\\][^/\\]+$/, '')
+    const sibling = `${dir}/ffprobe`
+    if (fs.existsSync(sibling)) return sibling
+  }
+  for (const p of ['/opt/homebrew/bin/ffprobe', '/usr/local/bin/ffprobe', '/usr/bin/ffprobe']) {
+    if (fs.existsSync(p)) return p
+  }
+  try {
+    const out = execFileSync('which', ['ffprobe'], { encoding: 'utf8' }).trim().split('\n')[0]
+    if (out && fs.existsSync(out)) return out
+  } catch {}
+  return null
+}
+
+export function ensureFfmpegOrThrow(): void {
+  if (!resolveFfmpegPath()) {
+    throw new Error(FFMPEG_MISSING_MESSAGE)
+  }
+}

--- a/backend/src/utils/json-refs.ts
+++ b/backend/src/utils/json-refs.ts
@@ -1,0 +1,14 @@
+/** 从 DB 中 JSON 字符串字段解析本地静态路径数组（如 reference_images） */
+export function parseStoredPathArray(raw: string | null | undefined, max = 6): string[] {
+  if (!raw) return []
+  try {
+    const arr = JSON.parse(raw)
+    if (!Array.isArray(arr)) return []
+    return arr
+      .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+      .map((x) => x.trim())
+      .slice(0, max)
+  } catch {
+    return []
+  }
+}

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -23,6 +23,12 @@ storage:
   local_path: "./data/storage"
   base_url: "http://localhost:5678/static"
 
+# 前端工作台「跳过视频合成」请在设置页切换，或构建时设置环境变量：
+# NUXT_PUBLIC_SKIP_VIDEO_COMPOSE=true
+# （本文件仅为说明，后端当前不读取该项）
+pipeline:
+  skip_video_compose: false
+
 ai:
   default_text_provider: "openai"
   default_image_provider: "openai"

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -35,6 +35,19 @@ export const api = {
   del: <T = any>(p: string) => req<T>('DELETE', p),
 }
 
+/** 上传图片到 `data/static/uploads/`，返回 `path`（如 `static/uploads/xxx.png`）供写入数据库 */
+export async function uploadImageFile(file: File): Promise<{ path: string; url: string }> {
+  const form = new FormData()
+  form.append('file', file)
+  const resp = await fetch(`${BASE}/upload/image`, { method: 'POST', body: form })
+  const json = await resp.json()
+  if (!resp.ok || (json.code && json.code >= 400)) {
+    throw new Error(json.message || `上传失败 ${resp.status}`)
+  }
+  const data = json.data ?? json
+  return { path: data.path, url: data.url }
+}
+
 export const dramaAPI = {
   list: () => api.get<{ items: any[] }>('/dramas'),
   get: (id: number) => api.get(`/dramas/${id}`),
@@ -67,6 +80,7 @@ export const characterAPI = {
 }
 
 export const sceneAPI = {
+  update: (id: number, data: any) => api.put(`/scenes/${id}`, data),
   generateImage: (id: number, episodeId: number) => api.post(`/scenes/${id}/generate-image`, { episode_id: episodeId }),
 }
 
@@ -97,6 +111,76 @@ export const composeAPI = {
 export const mergeAPI = {
   merge: (epId: number) => api.post(`/merge/episodes/${epId}/merge`),
   status: (epId: number) => api.get(`/merge/episodes/${epId}/merge`),
+  /** 删除本集全部拼接记录，并删除 static/merged 下对应成片 */
+  clear: (epId: number) =>
+    api.del<{ removed_files: number; removed_rows: number; cleared_episode_video: boolean }>(
+      `/merge/episodes/${epId}/merge`,
+    ),
+}
+
+export type TimelineRenderBody = {
+  video_segments: { path: string; in_sec: number; duration_sec: number }[]
+  audio_segments?: { path: string; in_sec: number; duration_sec: number }[] | null
+}
+
+/** 简易时间轴：音轨提取、裁切拼接导出（服务端 ffmpeg） */
+export const timelineAPI = {
+  extractAudio: (path: string) => api.post<{ path: string }>('/timeline/extract-audio', { path }),
+  render: (body: TimelineRenderBody) => api.post<{ path: string }>('/timeline/render', body),
+  /** NDJSON 流：多行 JSON，含 `{ progress }` 与最终 `{ path }` */
+  renderStream: async (body: TimelineRenderBody, onProgress: (pct: number) => void): Promise<{ path: string }> => {
+    const resp = await fetch(`${BASE}/timeline/render-stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const jsonErr = async () => {
+      const j = await resp.json().catch(() => ({} as { message?: string }))
+      return j.message || `${resp.status}`
+    }
+    if (!resp.ok) throw new Error(await jsonErr())
+    if (!resp.body) throw new Error('无响应体')
+
+    const reader = resp.body.getReader()
+    const dec = new TextDecoder()
+    let buf = ''
+    let outPath = ''
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += dec.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const line of lines) {
+        const t = line.trim()
+        if (!t) continue
+        let o: { progress?: number; path?: string; error?: string }
+        try {
+          o = JSON.parse(t) as { progress?: number; path?: string; error?: string }
+        } catch {
+          continue
+        }
+        if (typeof o.progress === 'number') onProgress(o.progress)
+        if (o.error) throw new Error(o.error)
+        if (o.path) outPath = o.path
+      }
+    }
+    const tail = buf.trim()
+    if (tail) {
+      try {
+        const o = JSON.parse(tail) as { progress?: number; path?: string; error?: string }
+        if (typeof o.progress === 'number') onProgress(o.progress)
+        if (o.error) throw new Error(o.error)
+        if (o.path) outPath = o.path
+      } catch (e) {
+        if (e instanceof SyntaxError) {
+          /* ignore */
+        } else throw e
+      }
+    }
+    if (!outPath) throw new Error('导出未完成')
+    return { path: outPath }
+  },
 }
 export const aiConfigAPI = {
   list: (t?: string) => api.get(`/ai-configs${t ? `?service_type=${t}` : ''}`),

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -75,13 +75,21 @@ export const storyboardAPI = {
 export const characterAPI = {
   update: (id: number, data: any) => api.put(`/characters/${id}`, data),
   voiceSample: (id: number, episodeId: number) => api.post(`/characters/${id}/generate-voice-sample`, { episode_id: episodeId }),
-  generateImage: (id: number, episodeId: number) => api.post(`/characters/${id}/generate-image`, { episode_id: episodeId }),
+  generateImage: (id: number, episodeId: number, extra?: { prompt?: string }) =>
+    api.post(`/characters/${id}/generate-image`, {
+      episode_id: episodeId,
+      ...(extra?.prompt !== undefined ? { prompt: extra.prompt } : {}),
+    }),
   batchImages: (ids: number[], episodeId: number) => api.post('/characters/batch-generate-images', { character_ids: ids, episode_id: episodeId }),
 }
 
 export const sceneAPI = {
   update: (id: number, data: any) => api.put(`/scenes/${id}`, data),
-  generateImage: (id: number, episodeId: number) => api.post(`/scenes/${id}/generate-image`, { episode_id: episodeId }),
+  generateImage: (id: number, episodeId: number, extra?: { prompt?: string }) =>
+    api.post(`/scenes/${id}/generate-image`, {
+      episode_id: episodeId,
+      ...(extra?.prompt !== undefined ? { prompt: extra.prompt } : {}),
+    }),
 }
 
 export const imageAPI = {

--- a/frontend/app/composables/usePipelinePrefs.ts
+++ b/frontend/app/composables/usePipelinePrefs.ts
@@ -1,0 +1,33 @@
+/**
+ * 制作流水线偏好（本地持久化 + 可选构建时默认）
+ */
+const STORAGE_KEY = 'huobao:pipeline:skipVideoCompose'
+
+const skipVideoCompose = ref(false)
+let synced = false
+
+function readInitial(): boolean {
+  if (!import.meta.client) return false
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (raw !== null) return raw === '1' || raw === 'true'
+  try {
+    const pub = useRuntimeConfig().public as { skipVideoCompose?: boolean }
+    return !!pub.skipVideoCompose
+  } catch {
+    return false
+  }
+}
+
+export function usePipelinePrefs() {
+  if (import.meta.client && !synced) {
+    synced = true
+    skipVideoCompose.value = readInitial()
+  }
+
+  function setSkipVideoCompose(v: boolean) {
+    skipVideoCompose.value = v
+    if (import.meta.client) localStorage.setItem(STORAGE_KEY, v ? '1' : '0')
+  }
+
+  return { skipVideoCompose, setSkipVideoCompose }
+}

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -153,6 +153,13 @@ const showBrandImage = ref(true)
 .film-frame:nth-child(2) { background: var(--accent); opacity: 0.6; }
 .film-frame:nth-child(3) { opacity: 0.3; }
 
-/* Content */
-.content { flex: 1; overflow: hidden; display: flex; flex-direction: column; }
+/* Content：可纵向滚动（简易剪辑等长页）；min-height:0 避免 flex 子项被内容撑开却无法出现滚动条 */
+.content {
+  flex: 1;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
 </style>

--- a/frontend/app/pages/drama/[id]/episode/[episodeNumber]/edit.vue
+++ b/frontend/app/pages/drama/[id]/episode/[episodeNumber]/edit.vue
@@ -1,0 +1,1244 @@
+<template>
+  <div class="te-page" v-if="drama">
+    <header class="te-top">
+      <button type="button" class="back-btn" @click="navigateTo(`/drama/${dramaId}/episode/${episodeNumber}`)">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/>
+        </svg>
+        返回本集工作台
+      </button>
+      <div class="te-title-block">
+        <h1 class="te-title">{{ drama.title }}</h1>
+        <span class="te-chip">第 {{ episodeNumber }} 集 · 简易剪辑</span>
+      </div>
+      <div class="te-actions">
+        <span class="te-timecode" title="播放头 / 总时长">{{ formatTc(playheadSec) }} / {{ formatTc(totalDuration) }}</span>
+        <label class="te-zoom">
+          缩放
+          <input v-model.number="pxPerSec" type="range" min="28" max="100" />
+        </label>
+        <button type="button" class="btn btn-primary" :disabled="!exportableClips.length || rendering" @click="doRender">
+          {{ rendering ? `导出中 ${renderProgress}%` : '导出成片' }}
+        </button>
+      </div>
+    </header>
+
+    <div v-if="loadError" class="te-empty">{{ loadError }}</div>
+    <div v-else-if="loading" class="te-empty">加载中…</div>
+    <template v-else>
+      <section class="te-preview">
+        <video
+          v-if="previewSrcUrl"
+          ref="previewRef"
+          :src="previewSrcUrl"
+          class="te-video"
+          controls
+          playsinline
+          preload="metadata"
+          @play="previewFollowTimeline = true"
+          @pause="previewFollowTimeline = false"
+          @timeupdate="onPreviewTimeUpdate"
+          @seeked="onPreviewSeeked"
+        />
+        <p v-else class="te-hint">本集暂无可剪辑的镜头视频（需已生成视频；若无生成视频则可使用已合成成片）</p>
+        <p v-if="previewSrcUrl" class="te-preview-hint">空格 播放/暂停 · 时间线可点按拖动红线对位 · 播放时播放头跟随</p>
+      </section>
+
+      <section class="te-toolbar card-like">
+        <div class="te-toolbar-group">
+          <span class="te-toolbar-label">片段</span>
+          <button type="button" class="btn btn-sm" :disabled="selectedVideoIdx === null" @click="splitAtPlayhead">在当前位置分割</button>
+          <button type="button" class="btn btn-sm" :disabled="selectedVideoIdx === null" @click="duplicateSelected">复制</button>
+          <button type="button" class="btn btn-sm" :disabled="selectedVideoIdx === null" @click="deleteSelected">删除</button>
+          <button type="button" class="btn btn-sm" :disabled="selectedVideoIdx === null" @click="toggleSelectedEnabled">
+            {{ selectedClip && selectedClip.enabled === false ? '启用选中' : '禁用选中' }}
+          </button>
+        </div>
+        <div class="te-toolbar-group">
+          <span class="te-toolbar-label">编辑</span>
+          <button type="button" class="btn btn-sm btn-ghost" :disabled="!canUndo" @click="undo">撤销</button>
+          <button type="button" class="btn btn-sm btn-ghost" :disabled="!canRedo" @click="redo">重做</button>
+          <label class="te-check te-check-inline">
+            <input v-model="snapEnabled" type="checkbox" />
+            吸附 0.1s
+          </label>
+        </div>
+        <div class="te-toolbar-hint">
+          快捷键：Space 播放 · ←/→ 逐帧感移动 · Home/End 到头尾 · Ctrl+Z / Ctrl+Shift+Z 撤销/重做 · Delete 删选中
+        </div>
+      </section>
+
+      <section class="te-panel">
+        <div class="te-row">
+          <label class="te-check">
+            <input v-model="audioLinked" type="checkbox" />
+            音画联动（改顺序或入出点会同步到音轨）
+          </label>
+        </div>
+        <div class="te-row te-source-row">
+          <label class="te-check">
+            <input v-model="preferComposedVideo" type="checkbox" />
+            素材改用「视频合成」成片（默认用「视频生成」原始视频）
+          </label>
+        </div>
+
+        <div class="te-track-head">
+          <span class="te-track-label">视频轨</span>
+          <span class="te-dim">点击片段可选中；拖排序；左右黄条裁剪；灰条为禁用（导出跳过）</span>
+        </div>
+
+        <div
+          ref="scrubAreaRef"
+          class="te-scrub-stack"
+          :style="{ width: Math.max(totalWidthPx, 320) + 'px' }"
+          @pointerdown="onScrubAreaPointerDown"
+        >
+          <div class="te-ruler te-ruler-scrub" :style="{ width: totalWidthPx + 'px' }">
+            <span v-for="t in rulerTicks" :key="t" class="te-tick" :style="{ left: t * pxPerSec + 'px' }">{{ t }}s</span>
+          </div>
+          <div class="te-playhead" :style="{ left: playheadXPx + 'px' }" title="拖动或点击时间线移动播放头" @pointerdown.stop="startPlayheadDrag" />
+
+          <div class="te-track te-track-video" :style="{ width: totalWidthPx + 'px' }">
+            <div
+              v-for="(c, idx) in videoClips"
+              :key="c.id"
+              class="te-clip"
+              :class="{
+                dragging: dragVideoIdx === idx,
+                selected: selectedVideoIdx === idx,
+                disabled: c.enabled === false,
+              }"
+              :style="{ width: clipWidthPx(c) + 'px' }"
+              draggable="true"
+              @dragstart="onDragStart('v', idx, $event)"
+              @dragend="clearDrag"
+              @dragover.prevent
+              @drop="onDrop('v', idx)"
+              @pointerdown="onClipPointerDown('v', idx, $event)"
+            >
+              <div
+                class="te-handle te-handle-l"
+                title="拖曳裁剪入点"
+                @pointerdown.stop="startTrim($event, 'v', idx, 'in')"
+              />
+              <div class="te-clip-body" :title="c.label">
+                <span class="te-clip-name">{{ c.label }}</span>
+                <span class="te-clip-meta">{{ c.in.toFixed(2) }}s · {{ c.dur.toFixed(2) }}s</span>
+              </div>
+              <div
+                class="te-handle te-handle-r"
+                title="拖曳裁剪出点"
+                @pointerdown.stop="startTrim($event, 'v', idx, 'out')"
+              />
+            </div>
+          </div>
+
+          <div class="te-track-head te-track-head-inner">
+            <span class="te-track-label">音频轨</span>
+            <span class="te-dim">{{ audioLinked ? '与视频轨一致' : '可单独排序与裁剪' }}</span>
+          </div>
+          <div class="te-track te-track-audio" :style="{ width: audioTotalWidthPx + 'px' }">
+            <div
+              v-for="(c, idx) in displayAudioClips"
+              :key="c.id"
+              class="te-clip te-clip-audio"
+              :class="{
+                dragging: dragAudioIdx === idx,
+                muted: audioLinked,
+                disabled: c.enabled === false,
+                selected: !audioLinked && selectedAudioIdx === idx,
+              }"
+              :style="{ width: clipWidthPx(c) + 'px' }"
+              :draggable="!audioLinked"
+              @dragstart="!audioLinked && onDragStart('a', idx, $event)"
+              @dragend="clearDrag"
+              @dragover.prevent
+              @drop="!audioLinked && onDrop('a', idx)"
+              @pointerdown="!audioLinked && onClipPointerDown('a', idx, $event)"
+            >
+              <div
+                class="te-handle te-handle-l"
+                @pointerdown.stop="!audioLinked && startTrim($event, 'a', idx, 'in')"
+              />
+              <div class="te-clip-body">
+                <span class="te-clip-name">{{ c.label }}</span>
+                <span class="te-clip-meta">{{ c.in.toFixed(2) }}s · {{ c.dur.toFixed(2) }}s</span>
+              </div>
+              <div
+                class="te-handle te-handle-r"
+                @pointerdown.stop="!audioLinked && startTrim($event, 'a', idx, 'out')"
+              />
+            </div>
+          </div>
+        </div>
+
+        <p v-if="exportUrl" class="te-export">
+          已生成：
+          <a :href="'/' + exportUrl" target="_blank" rel="noopener">{{ exportUrl }}</a>
+          <a :href="'/' + exportUrl" download class="btn btn-sm" style="margin-left:8px">下载</a>
+        </p>
+      </section>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
+import { dramaAPI, episodeAPI, timelineAPI } from '~/composables/useApi'
+
+interface Clip {
+  id: string
+  sbId: number
+  label: string
+  path: string
+  full: number
+  in: number
+  dur: number
+  /** false 时导出跳过该段，时间轴仍占位 */
+  enabled?: boolean
+}
+
+const route = useRoute()
+const dramaId = Number(route.params.id)
+const episodeNumber = Number(route.params.episodeNumber)
+
+const drama = ref<any>(null)
+const loading = ref(true)
+const loadError = ref('')
+const videoClips = ref<Clip[]>([])
+const audioClips = ref<Clip[]>([])
+const audioLinked = ref(true)
+const preferComposedVideo = ref(false)
+const pxPerSec = ref(48)
+const rendering = ref(false)
+/** 导出成片进度 0–100（按服务端 ffmpeg 阶段计步） */
+const renderProgress = ref(0)
+const exportUrl = ref('')
+const previewRef = ref<HTMLVideoElement | null>(null)
+const previewSrcUrl = ref('')
+const previewClipIdx = ref(0)
+const playheadSec = ref(0)
+const previewFollowTimeline = ref(false)
+const snapEnabled = ref(true)
+const selectedVideoIdx = ref<number | null>(null)
+const selectedAudioIdx = ref<number | null>(null)
+const scrubAreaRef = ref<HTMLElement | null>(null)
+
+const dragVideoIdx = ref<number | null>(null)
+const dragAudioIdx = ref<number | null>(null)
+let dragKind: 'v' | 'a' | null = null
+
+const undoStack = ref<string[]>([])
+const redoStack = ref<string[]>([])
+const MAX_HISTORY = 40
+
+const canUndo = computed(() => undoStack.value.length > 0)
+const canRedo = computed(() => redoStack.value.length > 0)
+
+const exportableClips = computed(() => videoClips.value.filter((c) => c.enabled !== false))
+
+const totalDuration = computed(() =>
+  videoClips.value.reduce((s, c) => s + c.dur, 0),
+)
+
+const clipStartTimes = computed(() => {
+  const arr: number[] = []
+  let acc = 0
+  for (const c of videoClips.value) {
+    arr.push(acc)
+    acc += c.dur
+  }
+  return arr
+})
+
+const playheadXPx = computed(() => playheadSec.value * pxPerSec.value)
+
+const selectedClip = computed(() => {
+  const i = selectedVideoIdx.value
+  if (i === null) return null
+  return videoClips.value[i] ?? null
+})
+
+function clipWidthPx(c: Clip) {
+  return Math.max(24, c.dur * pxPerSec.value)
+}
+
+const totalWidthPx = computed(() =>
+  videoClips.value.reduce((s, c) => s + clipWidthPx(c), 0),
+)
+
+const displayAudioClips = computed<Clip[]>(() => {
+  if (audioLinked.value) {
+    return videoClips.value.map((c) => ({
+      ...c,
+      id: `${c.id}-audio-mirror`,
+      label: `${c.label} · 音`,
+    }))
+  }
+  return audioClips.value
+})
+
+const audioTotalWidthPx = computed(() =>
+  displayAudioClips.value.reduce((s, c) => s + clipWidthPx(c), 0),
+)
+
+const rulerTicks = computed(() => {
+  const totalSec = totalDuration.value
+  const step = totalSec > 120 ? 15 : totalSec > 60 ? 10 : 5
+  const ticks: number[] = []
+  for (let t = 0; t <= totalSec + 0.001; t += step) ticks.push(Math.round(t))
+  return ticks
+})
+
+function formatTc(sec: number) {
+  const s = Math.max(0, sec)
+  const m = Math.floor(s / 60)
+  const r = s - m * 60
+  return `${m}:${r.toFixed(1).padStart(4, '0')}`
+}
+
+function snapshotState(): string {
+  return JSON.stringify({
+    v: videoClips.value,
+    a: audioClips.value,
+    linked: audioLinked.value,
+    playhead: playheadSec.value,
+  })
+}
+
+function pushHistory() {
+  undoStack.value.push(snapshotState())
+  if (undoStack.value.length > MAX_HISTORY) undoStack.value.shift()
+  redoStack.value = []
+}
+
+function restoreState(raw: string) {
+  try {
+    const o = JSON.parse(raw)
+    videoClips.value = o.v
+    audioClips.value = o.a
+    audioLinked.value = o.linked
+    playheadSec.value = Math.min(o.playhead ?? 0, totalDuration.value || 0)
+    selectedVideoIdx.value = null
+    selectedAudioIdx.value = null
+    nextTick(() => syncPreviewToPlayhead())
+  } catch {
+    /* ignore */
+  }
+}
+
+function undo() {
+  if (!undoStack.value.length) return
+  const cur = snapshotState()
+  const prev = undoStack.value.pop()!
+  redoStack.value.push(cur)
+  restoreState(prev)
+}
+
+function redo() {
+  if (!redoStack.value.length) return
+  const cur = snapshotState()
+  const next = redoStack.value.pop()!
+  undoStack.value.push(cur)
+  restoreState(next)
+}
+
+watch(audioLinked, (linked) => {
+  if (!linked) {
+    audioClips.value = videoClips.value.map((c) => ({
+      ...c,
+      id: crypto.randomUUID(),
+      label: `${c.label} · 音`,
+    }))
+  }
+})
+
+function getEditClipPath(sb: any): string | null {
+  const raw = sb.video_url || sb.videoUrl
+  const composed = sb.composed_video_url || sb.composedVideoUrl
+  const p = preferComposedVideo.value
+    ? (composed || raw)
+    : (raw || composed)
+  return p ? String(p).replace(/^\//, '') : null
+}
+
+async function rebuildClipsFromStoryboards(sbs: any[]) {
+  const clips: Clip[] = []
+  let i = 0
+  for (const sb of sbs) {
+    const path = getEditClipPath(sb)
+    if (!path) continue
+    const num = sb.storyboard_number ?? sb.storyboardNumber ?? ++i
+    const full = await probeDuration(path)
+    clips.push({
+      id: crypto.randomUUID(),
+      sbId: sb.id,
+      label: `镜${String(num).padStart(2, '0')}`,
+      path,
+      full,
+      in: 0,
+      dur: full,
+      enabled: true,
+    })
+  }
+  videoClips.value = clips
+}
+
+watch(preferComposedVideo, async () => {
+  if (loading.value || !drama.value) return
+  const ep = (drama.value.episodes || []).find(
+    (e: any) => (e.episode_number ?? e.episodeNumber) === episodeNumber,
+  )
+  if (!ep?.id) return
+  try {
+    const sbs = await episodeAPI.storyboards(ep.id)
+    await rebuildClipsFromStoryboards(sbs)
+    if (!audioLinked.value) {
+      audioClips.value = videoClips.value.map((c) => ({
+        ...c,
+        id: crypto.randomUUID(),
+        label: `${c.label} · 音`,
+      }))
+    }
+    playheadSec.value = 0
+    nextTick(() => syncPreviewToPlayhead())
+  } catch (e: any) {
+    toast.error(e?.message || '切换素材来源失败')
+  }
+})
+
+function probeDuration(relPath: string): Promise<number> {
+  return new Promise((resolve) => {
+    const v = document.createElement('video')
+    v.preload = 'metadata'
+    v.src = `/${relPath.replace(/^\//, '')}`
+    const done = (sec: number) => {
+      v.remove()
+      resolve(sec > 0 && Number.isFinite(sec) ? sec : 8)
+    }
+    v.onloadedmetadata = () => done(v.duration)
+    v.onerror = () => done(8)
+  })
+}
+
+function clipAtSequenceTime(sec: number): { idx: number; local: number } | null {
+  const clips = videoClips.value
+  if (!clips.length) return null
+  let acc = 0
+  const t = Math.max(0, Math.min(sec, totalDuration.value))
+  for (let i = 0; i < clips.length; i++) {
+    const c = clips[i]
+    const d = c.dur
+    if (t < acc + d - 1e-6) return { idx: i, local: t - acc }
+    acc += d
+  }
+  const last = clips.length - 1
+  return { idx: last, local: clips[last].dur }
+}
+
+function syncPreviewToPlayhead() {
+  const hit = clipAtSequenceTime(playheadSec.value)
+  const v = previewRef.value
+  if (!hit || !v || !videoClips.value.length) {
+    if (videoClips.value[0]) {
+      const c0 = videoClips.value[0]
+      previewSrcUrl.value = `/${c0.path.replace(/^\//, '')}`
+      previewClipIdx.value = 0
+    } else {
+      previewSrcUrl.value = ''
+    }
+    return
+  }
+  const c = videoClips.value[hit.idx]
+  const src = `/${c.path.replace(/^\//, '')}`
+  const mediaTime = Math.min(c.in + hit.local, c.in + c.dur - 0.04)
+  if (previewClipIdx.value !== hit.idx || previewSrcUrl.value !== src) {
+    previewClipIdx.value = hit.idx
+    previewSrcUrl.value = src
+    v.pause()
+    const setT = () => {
+      try {
+        v.currentTime = Math.max(c.in, mediaTime)
+      } catch {
+        /* ignore */
+      }
+    }
+    if (v.readyState >= 1) setT()
+    else v.addEventListener('loadedmetadata', setT, { once: true })
+  } else {
+    try {
+      v.currentTime = Math.max(c.in, mediaTime)
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+watch([playheadSec, videoClips], () => {
+  if (!previewFollowTimeline.value) syncPreviewToPlayhead()
+})
+
+watch(totalDuration, (d) => {
+  if (playheadSec.value > d) playheadSec.value = Math.max(0, d)
+})
+
+let playheadDrag: { startX: number; startSec: number } | null = null
+
+function startPlayheadDrag(e: PointerEvent) {
+  const el = e.currentTarget as HTMLElement
+  el.setPointerCapture?.(e.pointerId)
+  playheadDrag = { startX: e.clientX, startSec: playheadSec.value }
+  previewFollowTimeline.value = false
+}
+
+function onScrubAreaPointerDown(e: PointerEvent) {
+  if ((e.target as HTMLElement).closest('.te-playhead')) return
+  if ((e.target as HTMLElement).closest('.te-clip')) return
+  if ((e.target as HTMLElement).closest('.te-handle')) return
+  const area = scrubAreaRef.value
+  if (!area) return
+  const r = area.getBoundingClientRect()
+  const x = e.clientX - r.left
+  playheadSec.value = Math.max(0, Math.min(x / pxPerSec.value, totalDuration.value))
+  previewFollowTimeline.value = false
+  syncPreviewToPlayhead()
+}
+
+function applyPlayheadMove(e: PointerEvent) {
+  if (!playheadDrag) return
+  const dx = e.clientX - playheadDrag.startX
+  const ds = dx / pxPerSec.value
+  playheadSec.value = Math.max(0, Math.min(playheadDrag.startSec + ds, totalDuration.value))
+}
+
+function onPlayheadPointerUp(e: PointerEvent) {
+  if (playheadDrag) {
+    try {
+      ;(e.target as HTMLElement).releasePointerCapture?.(e.pointerId)
+    } catch {
+      /* ignore */
+    }
+    playheadDrag = null
+    syncPreviewToPlayhead()
+  }
+}
+
+function onPreviewTimeUpdate() {
+  if (!previewFollowTimeline.value) return
+  const v = previewRef.value
+  if (!v) return
+  const idx = previewClipIdx.value
+  const c = videoClips.value[idx]
+  if (!c) return
+  const starts = clipStartTimes.value
+  const seq = (starts[idx] ?? 0) + (v.currentTime - c.in)
+  playheadSec.value = Math.max(0, Math.min(seq, totalDuration.value))
+}
+
+function onPreviewSeeked() {
+  if (previewFollowTimeline.value) onPreviewTimeUpdate()
+}
+
+function togglePreviewPlay() {
+  const v = previewRef.value
+  if (!v || !previewSrcUrl.value) return
+  if (v.paused) {
+    previewFollowTimeline.value = true
+    void v.play()
+  } else {
+    v.pause()
+  }
+}
+
+function onKeyDown(e: KeyboardEvent) {
+  const t = e.target as HTMLElement
+  if (t?.tagName === 'INPUT' || t?.tagName === 'TEXTAREA' || t?.isContentEditable) return
+  if (e.code === 'Space') {
+    e.preventDefault()
+    togglePreviewPlay()
+    return
+  }
+  if (e.key === 'Delete' || e.key === 'Backspace') {
+    e.preventDefault()
+    deleteSelected()
+    return
+  }
+  if (e.ctrlKey && e.key.toLowerCase() === 'z' && !e.shiftKey) {
+    e.preventDefault()
+    undo()
+    return
+  }
+  if ((e.ctrlKey && e.key.toLowerCase() === 'y') || (e.ctrlKey && e.shiftKey && e.key.toLowerCase() === 'z')) {
+    e.preventDefault()
+    redo()
+    return
+  }
+  const step = e.shiftKey ? 1 : 1 / 6
+  if (e.key === 'ArrowLeft') {
+    e.preventDefault()
+    playheadSec.value = Math.max(0, playheadSec.value - step)
+    previewFollowTimeline.value = false
+    syncPreviewToPlayhead()
+    return
+  }
+  if (e.key === 'ArrowRight') {
+    e.preventDefault()
+    playheadSec.value = Math.min(totalDuration.value, playheadSec.value + step)
+    previewFollowTimeline.value = false
+    syncPreviewToPlayhead()
+    return
+  }
+  if (e.key === 'Home') {
+    e.preventDefault()
+    playheadSec.value = 0
+    previewFollowTimeline.value = false
+    syncPreviewToPlayhead()
+    return
+  }
+  if (e.key === 'End') {
+    e.preventDefault()
+    playheadSec.value = totalDuration.value
+    previewFollowTimeline.value = false
+    syncPreviewToPlayhead()
+    return
+  }
+}
+
+function onClipPointerDown(kind: 'v' | 'a', idx: number, e: PointerEvent) {
+  if ((e.target as HTMLElement).closest('.te-handle')) return
+  if (kind === 'v') {
+    selectedVideoIdx.value = idx
+    selectedAudioIdx.value = null
+  } else {
+    selectedAudioIdx.value = idx
+    selectedVideoIdx.value = null
+  }
+}
+
+function splitAtPlayhead() {
+  const t = playheadSec.value
+  const hit = clipAtSequenceTime(t)
+  if (!hit) return
+  const i = hit.idx
+  const c = videoClips.value[i]
+  const local = hit.local
+  if (local <= MIN_DUR || local >= c.dur - MIN_DUR) {
+    toast.warning('播放头需落在片段中间（距两端至少 0.2s）')
+    return
+  }
+  pushHistory()
+  const left: Clip = {
+    ...c,
+    id: crypto.randomUUID(),
+    dur: local,
+  }
+  const right: Clip = {
+    ...c,
+    id: crypto.randomUUID(),
+    in: c.in + local,
+    dur: c.dur - local,
+  }
+  const arr = [...videoClips.value]
+  arr.splice(i, 1, left, right)
+  videoClips.value = arr
+  if (!audioLinked.value) {
+    const ac = audioClips.value[i]
+    if (ac) {
+      const al: Clip = { ...ac, id: crypto.randomUUID(), dur: local }
+      const ar: Clip = { ...ac, id: crypto.randomUUID(), in: ac.in + local, dur: ac.dur - local }
+      const a2 = [...audioClips.value]
+      a2.splice(i, 1, al, ar)
+      audioClips.value = a2
+    }
+  }
+  selectedVideoIdx.value = i + 1
+  nextTick(() => syncPreviewToPlayhead())
+  toast.success('已分割')
+}
+
+function duplicateSelected() {
+  const i = selectedVideoIdx.value
+  if (i === null) return
+  pushHistory()
+  const c = videoClips.value[i]
+  const copy: Clip = { ...c, id: crypto.randomUUID() }
+  const arr = [...videoClips.value]
+  arr.splice(i + 1, 0, copy)
+  videoClips.value = arr
+  if (!audioLinked.value) {
+    const ac = audioClips.value[i]
+    if (ac) {
+      const acopy: Clip = { ...ac, id: crypto.randomUUID() }
+      const a2 = [...audioClips.value]
+      a2.splice(i + 1, 0, acopy)
+      audioClips.value = a2
+    }
+  }
+  selectedVideoIdx.value = i + 1
+  nextTick(() => syncPreviewToPlayhead())
+}
+
+function deleteSelected() {
+  const i = selectedVideoIdx.value
+  if (i === null) return
+  if (videoClips.value.length <= 1) {
+    toast.warning('至少保留一段视频')
+    return
+  }
+  pushHistory()
+  const arr = [...videoClips.value]
+  arr.splice(i, 1)
+  videoClips.value = arr
+  if (!audioLinked.value) {
+    const a2 = [...audioClips.value]
+    if (a2[i]) a2.splice(i, 1)
+    audioClips.value = a2
+  }
+  selectedVideoIdx.value = null
+  if (playheadSec.value > totalDuration.value) playheadSec.value = totalDuration.value
+  nextTick(() => syncPreviewToPlayhead())
+}
+
+function toggleSelectedEnabled() {
+  const i = selectedVideoIdx.value
+  if (i === null) return
+  pushHistory()
+  const c = videoClips.value[i]
+  const turnOn = c.enabled === false
+  videoClips.value = videoClips.value.map((x, j) =>
+    j === i ? { ...x, enabled: turnOn } : x,
+  )
+  if (!audioLinked.value && audioClips.value[i]) {
+    const en = videoClips.value[i].enabled !== false
+    audioClips.value = audioClips.value.map((x, j) =>
+      j === i ? { ...x, enabled: en } : x,
+    )
+  }
+}
+
+onMounted(async () => {
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUpGlobal)
+  window.addEventListener('pointercancel', onPointerUpGlobal)
+  window.addEventListener('keydown', onKeyDown)
+
+  try {
+    const d = await dramaAPI.get(dramaId)
+    drama.value = d
+    const ep = (d.episodes || []).find(
+      (e: any) => (e.episode_number ?? e.episodeNumber) === episodeNumber,
+    )
+    if (!ep) {
+      loadError.value = '找不到该集'
+      return
+    }
+    const sbs = await episodeAPI.storyboards(ep.id)
+    await rebuildClipsFromStoryboards(sbs)
+    playheadSec.value = 0
+    await nextTick()
+    syncPreviewToPlayhead()
+  } catch (e: any) {
+    loadError.value = e?.message || '加载失败'
+    toast.error(loadError.value)
+  } finally {
+    loading.value = false
+  }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('pointermove', onPointerMove)
+  window.removeEventListener('pointerup', onPointerUpGlobal)
+  window.removeEventListener('pointercancel', onPointerUpGlobal)
+  window.removeEventListener('keydown', onKeyDown)
+})
+
+function onDragStart(kind: 'v' | 'a', idx: number, e: DragEvent) {
+  dragKind = kind
+  if (kind === 'v') dragVideoIdx.value = idx
+  else dragAudioIdx.value = idx
+  e.dataTransfer!.effectAllowed = 'move'
+  try {
+    e.dataTransfer!.setData('text/plain', String(idx))
+  } catch {
+    /* ignore */
+  }
+}
+
+function clearDrag() {
+  dragVideoIdx.value = dragAudioIdx.value = null
+  dragKind = null
+}
+
+function onDrop(kind: 'v' | 'a', toIdx: number) {
+  const fromIdx = kind === 'v' ? dragVideoIdx.value : dragAudioIdx.value
+  if (fromIdx === null || fromIdx === undefined || fromIdx === toIdx) {
+    clearDrag()
+    return
+  }
+  pushHistory()
+  const arr = kind === 'v' ? [...videoClips.value] : [...audioClips.value]
+  const [item] = arr.splice(fromIdx, 1)
+  arr.splice(toIdx, 0, item)
+  if (kind === 'v') {
+    videoClips.value = arr
+    selectedVideoIdx.value = toIdx
+  } else {
+    audioClips.value = arr
+    selectedAudioIdx.value = toIdx
+  }
+  clearDrag()
+  nextTick(() => syncPreviewToPlayhead())
+}
+
+const MIN_DUR = 0.2
+
+type TrimEdge = 'in' | 'out'
+let trimState: {
+  kind: 'v' | 'a'
+  idx: number
+  edge: TrimEdge
+  startX: number
+  clip: Clip
+  captureEl: HTMLElement | null
+} | null = null
+
+function startTrim(e: PointerEvent, kind: 'v' | 'a', idx: number, edge: TrimEdge) {
+  const list = kind === 'v' ? videoClips.value : audioClips.value
+  const c = list[idx]
+  if (!c) return
+  pushHistory()
+  const el = e.currentTarget as HTMLElement
+  el.setPointerCapture?.(e.pointerId)
+  trimState = {
+    kind,
+    idx,
+    edge,
+    startX: e.clientX,
+    clip: { ...c },
+    captureEl: el,
+  }
+}
+
+function snapClipTimes(c: Clip) {
+  if (!snapEnabled.value) return
+  c.in = Math.round(c.in * 10) / 10
+  c.dur = Math.round(c.dur * 10) / 10
+  c.in = Math.max(0, Math.min(c.in, c.full - MIN_DUR))
+  c.dur = Math.max(MIN_DUR, Math.min(c.dur, c.full - c.in))
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (playheadDrag) {
+    applyPlayheadMove(e)
+    syncPreviewToPlayhead()
+    return
+  }
+  if (!trimState) return
+  const dx = e.clientX - trimState.startX
+  const ds = dx / pxPerSec.value
+  const orig = trimState.clip
+  const list = trimState.kind === 'v' ? videoClips.value : audioClips.value
+  const cur = list[trimState.idx]
+  if (!cur) return
+
+  if (trimState.edge === 'in') {
+    const end = orig.in + orig.dur
+    let newIn = orig.in + ds
+    newIn = Math.max(0, Math.min(newIn, end - MIN_DUR))
+    cur.in = newIn
+    cur.dur = end - newIn
+  } else {
+    let newDur = orig.dur + ds
+    newDur = Math.max(MIN_DUR, Math.min(newDur, orig.full - orig.in))
+    cur.dur = newDur
+  }
+}
+
+function onPointerUpGlobal(e: PointerEvent) {
+  if (trimState?.captureEl) {
+    try {
+      trimState.captureEl.releasePointerCapture?.(e.pointerId)
+    } catch {
+      /* ignore */
+    }
+    const list = trimState.kind === 'v' ? videoClips.value : audioClips.value
+    const cur = list[trimState.idx]
+    if (cur) snapClipTimes(cur)
+    if (!audioLinked.value) {
+      const vc = videoClips.value[trimState.idx]
+      const ac = audioClips.value[trimState.idx]
+      if (vc && ac) {
+        if (trimState.kind === 'v') {
+          ac.in = vc.in
+          ac.dur = vc.dur
+        } else {
+          vc.in = ac.in
+          vc.dur = ac.dur
+        }
+      }
+    }
+    trimState = null
+    nextTick(() => syncPreviewToPlayhead())
+  }
+  onPlayheadPointerUp(e)
+}
+
+async function doRender() {
+  const enabledIdx = videoClips.value.reduce<number[]>((acc, c, i) => {
+    if (c.enabled !== false) acc.push(i)
+    return acc
+  }, [])
+  if (!enabledIdx.length) {
+    toast.warning('没有可导出的片段（请启用至少一段视频）')
+    return
+  }
+  rendering.value = true
+  exportUrl.value = ''
+  try {
+    const video_segments = enabledIdx.map((i) => {
+      const c = videoClips.value[i]
+      return {
+        path: c.path.replace(/^\//, ''),
+        in_sec: c.in,
+        duration_sec: c.dur,
+      }
+    })
+    let audio_segments: { path: string; in_sec: number; duration_sec: number }[]
+    if (audioLinked.value) {
+      audio_segments = video_segments.map((s) => ({ ...s }))
+    } else {
+      if (audioClips.value.length !== videoClips.value.length) {
+        toast.warning('音轨与视频轨条数不一致，请改回音画联动或重新载入本页')
+        rendering.value = false
+        renderProgress.value = 0
+        return
+      }
+      audio_segments = enabledIdx.map((i) => {
+        const c = audioClips.value[i]
+        return {
+          path: c.path.replace(/^\//, ''),
+          in_sec: c.in,
+          duration_sec: c.dur,
+        }
+      })
+    }
+    const { path } = await timelineAPI.renderStream({ video_segments, audio_segments }, (pct) => {
+      renderProgress.value = pct
+    })
+    exportUrl.value = path
+    renderProgress.value = 100
+    toast.success('导出完成')
+  } catch (err: any) {
+    toast.error(err?.message || '导出失败')
+  } finally {
+    rendering.value = false
+    renderProgress.value = 0
+  }
+}
+</script>
+
+<style scoped>
+.te-page {
+  min-height: 100vh;
+  background: var(--bg-base);
+  font-family: var(--font-body);
+  color: var(--text-0);
+  padding: var(--sp-5) var(--sp-6) var(--sp-10);
+}
+
+.te-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-6);
+}
+
+.te-title-block {
+  flex: 1;
+  min-width: 200px;
+}
+
+.te-title {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.te-chip {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--text-2);
+  padding: 2px 8px;
+  background: var(--bg-2);
+  border-radius: 99px;
+}
+
+.te-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+
+.te-timecode {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-1);
+  padding: 4px 8px;
+  background: var(--bg-2);
+  border-radius: var(--radius-sm);
+}
+
+.te-zoom {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.te-zoom input {
+  width: 100px;
+}
+
+.te-preview {
+  margin-bottom: var(--sp-4);
+}
+
+.te-video {
+  max-width: 720px;
+  width: 100%;
+  border-radius: var(--radius-lg);
+  background: #000;
+}
+
+.te-preview-hint {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.te-hint,
+.te-empty {
+  color: var(--text-2);
+  font-size: 14px;
+}
+
+.card-like {
+  background: var(--bg-0);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.te-toolbar {
+  padding: var(--sp-4);
+  margin-bottom: var(--sp-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.te-toolbar-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.te-toolbar-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-right: 4px;
+}
+
+.te-toolbar-hint {
+  font-size: 11px;
+  color: var(--text-3);
+  line-height: 1.45;
+}
+
+.te-check-inline {
+  margin: 0;
+}
+
+.te-panel {
+  background: var(--bg-0);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+  overflow-x: auto;
+}
+
+.te-row {
+  margin-bottom: var(--sp-4);
+}
+
+.te-check {
+  font-size: 13px;
+  color: var(--text-1);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.te-track-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+  margin-bottom: 6px;
+}
+
+.te-track-head-inner {
+  margin-top: 10px;
+}
+
+.te-track-label {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.te-dim {
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+.te-scrub-stack {
+  position: relative;
+  min-width: 0;
+}
+
+.te-ruler {
+  position: relative;
+  height: 18px;
+  margin-bottom: 4px;
+  border-bottom: 1px dashed var(--border);
+}
+
+.te-ruler-scrub {
+  cursor: pointer;
+}
+
+.te-tick {
+  position: absolute;
+  top: 0;
+  font-size: 10px;
+  color: var(--text-3);
+  transform: translateX(-2px);
+}
+
+.te-playhead {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  margin-left: -1px;
+  height: calc(100% - 4px);
+  background: var(--error);
+  z-index: 4;
+  pointer-events: auto;
+  cursor: ew-resize;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+.te-track {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  min-height: 52px;
+  gap: 0;
+  background: var(--bg-2);
+  border-radius: var(--radius);
+  padding: 4px;
+  position: relative;
+  z-index: 1;
+}
+
+.te-clip {
+  position: relative;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  background: linear-gradient(180deg, var(--bg-1), var(--bg-2));
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  cursor: grab;
+  user-select: none;
+  z-index: 2;
+}
+
+.te-clip.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-bg);
+}
+
+.te-clip.disabled {
+  opacity: 0.45;
+  filter: grayscale(0.35);
+}
+
+.te-clip.dragging {
+  opacity: 0.65;
+}
+
+.te-clip-audio.muted {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.te-clip-audio:not(.muted) {
+  cursor: grab;
+}
+
+.te-handle {
+  width: 10px;
+  flex-shrink: 0;
+  background: rgba(200, 170, 60, 0.35);
+  cursor: ew-resize;
+  z-index: 3;
+}
+
+.te-handle:hover {
+  background: rgba(200, 170, 60, 0.55);
+}
+
+.te-clip-body {
+  flex: 1;
+  min-width: 0;
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+}
+
+.te-clip-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.te-clip-meta {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-3);
+}
+
+.te-export {
+  margin-top: var(--sp-5);
+  font-size: 13px;
+}
+
+.te-export a {
+  color: var(--accent);
+}
+</style>

--- a/frontend/app/pages/drama/[id]/episode/[episodeNumber]/index.vue
+++ b/frontend/app/pages/drama/[id]/episode/[episodeNumber]/index.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="studio" v-if="drama">
+    <input ref="uploadInputRef" type="file" accept="image/*" class="sr-only" tabindex="-1" @change="onLocalImageSelected">
     <header class="studio-topbar">
       <div class="studio-topbar-main">
         <button class="back-btn topbar-back" @click="navigateTo(`/drama/${dramaId}`)">
@@ -13,7 +14,7 @@
           <span class="studio-episode-chip">第 {{ episodeNumber }} 集</span>
           <div class="studio-meta-row">
             <span class="studio-meta-pill">{{ currentSubStageLabel }}</span>
-            <span class="studio-meta-pill is-progress">{{ pipelineProgress }}/11</span>
+            <span class="studio-meta-pill is-progress">{{ pipelineProgress }}/{{ pipelineTotal }}</span>
             <span class="studio-meta-inline">{{ chars.length }} 角色 · {{ sbs.length }} 镜头</span>
           </div>
         </div>
@@ -503,6 +504,7 @@
                         />
                         <div v-else class="detail-preview-empty">待生成</div>
                       </div>
+                      <button type="button" class="detail-preview-upload" :disabled="uploading" @click="openLocalImageUpload({ kind: 'storyboard_frame', id: selectedSb.id, frameType: 'first_frame' })">本地上传</button>
                     </div>
                     <div class="detail-preview-card">
                       <div class="detail-preview-title">尾帧</div>
@@ -515,6 +517,7 @@
                         />
                         <div v-else class="detail-preview-empty">待生成</div>
                       </div>
+                      <button type="button" class="detail-preview-upload" :disabled="uploading" @click="openLocalImageUpload({ kind: 'storyboard_frame', id: selectedSb.id, frameType: 'last_frame' })">本地上传</button>
                     </div>
                   </div>
                 </div>
@@ -771,7 +774,10 @@
                 <div class="asset-foot">
                   <span :class="['dot', (c.image_url || c.imageUrl) && 'ok', isPendingCharImage(c.id) && 'pending']" />
                   <span class="dim" style="font-size:10px">{{ (c.image_url || c.imageUrl) ? '已生成' : (isPendingCharImage(c.id) ? '生成中' : '待生成') }}</span>
-                  <button class="btn btn-sm ml-auto" :disabled="isPendingCharImage(c.id)" @click="genCharImg(c.id)">{{ isPendingCharImage(c.id) ? '生成中' : '生成' }}</button>
+                  <div class="asset-foot-actions ml-auto">
+                    <button type="button" class="btn btn-sm btn-ghost" :disabled="uploading || isPendingCharImage(c.id)" @click="openLocalImageUpload({ kind: 'character', id: c.id })">本地上传</button>
+                    <button class="btn btn-sm" :disabled="isPendingCharImage(c.id)" @click="genCharImg(c.id)">{{ isPendingCharImage(c.id) ? '生成中' : '生成' }}</button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -810,7 +816,10 @@
                 <div class="asset-foot">
                   <span :class="['dot', (s.image_url || s.imageUrl) && 'ok', isPendingSceneImage(s.id) && 'pending']" />
                   <span class="dim" style="font-size:10px">{{ (s.image_url || s.imageUrl) ? '已生成' : (isPendingSceneImage(s.id) ? '生成中' : '待生成') }}</span>
-                  <button class="btn btn-sm ml-auto" :disabled="isPendingSceneImage(s.id)" @click="genSceneImg(s.id)">{{ isPendingSceneImage(s.id) ? '生成中' : '生成' }}</button>
+                  <div class="asset-foot-actions ml-auto">
+                    <button type="button" class="btn btn-sm btn-ghost" :disabled="uploading || isPendingSceneImage(s.id)" @click="openLocalImageUpload({ kind: 'scene', id: s.id })">本地上传</button>
+                    <button class="btn btn-sm" :disabled="isPendingSceneImage(s.id)" @click="genSceneImg(s.id)">{{ isPendingSceneImage(s.id) ? '生成中' : '生成' }}</button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -975,7 +984,10 @@
                           <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
                         </span>
                       </div>
-                      <span class="frame-thumb-label">{{ isPendingShotFrame(sb.id, 'first_frame') ? '首帧生成中' : '首帧' }}</span>
+                      <div class="frame-thumb-footer">
+                        <span class="frame-thumb-label">{{ isPendingShotFrame(sb.id, 'first_frame') ? '首帧生成中' : '首帧' }}</span>
+                        <button type="button" class="frame-thumb-upload" :disabled="uploading || isPendingShotFrame(sb.id, 'first_frame')" @click.stop="openLocalImageUpload({ kind: 'storyboard_frame', id: sb.id, frameType: 'first_frame' })">上传</button>
+                      </div>
                     </div>
                     <div v-if="frameMode === 'first_last'" class="frame-thumb-wrap">
                       <div class="frame-thumb" @click.stop="!isPendingShotFrame(sb.id, 'last_frame') && genShotFrame(sb, 'last_frame')">
@@ -993,8 +1005,14 @@
                           <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
                         </span>
                       </div>
-                      <span class="frame-thumb-label">{{ isPendingShotFrame(sb.id, 'last_frame') ? '尾帧生成中' : '尾帧' }}</span>
+                      <div class="frame-thumb-footer">
+                        <span class="frame-thumb-label">{{ isPendingShotFrame(sb.id, 'last_frame') ? '尾帧生成中' : '尾帧' }}</span>
+                        <button type="button" class="frame-thumb-upload" :disabled="uploading || isPendingShotFrame(sb.id, 'last_frame')" @click.stop="openLocalImageUpload({ kind: 'storyboard_frame', id: sb.id, frameType: 'last_frame' })">上传</button>
+                      </div>
                     </div>
+                  </div>
+                  <div class="frame-composed-upload">
+                    <button type="button" class="btn btn-xs btn-ghost" :disabled="uploading" @click.stop="openLocalImageUpload({ kind: 'storyboard_frame', id: sb.id, frameType: 'composed' })">上传镜头图（合成参考）</button>
                   </div>
                 </div>
               </div>
@@ -1048,6 +1066,7 @@
                   </div>
 
                   <div class="grid-tool-foot">
+                    <button type="button" class="btn btn-sm" :disabled="uploading" @click="openLocalImageUpload({ kind: 'grid' })">上传本地宫格图</button>
                     <span v-if="gridCanStart" class="tag mono">{{ gridAutoLayout.rows }}x{{ gridAutoLayout.cols }} = {{ gridAutoLayout.rows * gridAutoLayout.cols }}格</span>
                     <span class="dim" style="font-size:11px">{{ gridPromptLoading ? gridPromptStatus : gridSummary }}</span>
                     <button class="btn btn-primary ml-auto" :disabled="!gridCanStart || gridPromptLoading" @click="generateGridPrompt">
@@ -1082,6 +1101,7 @@
 
                   <div class="grid-tool-foot">
                     <button class="btn" @click="gridStep = 0">上一步</button>
+                    <button type="button" class="btn btn-sm" :disabled="uploading" @click="openLocalImageUpload({ kind: 'grid' })">上传本地宫格图</button>
                     <button class="btn ml-auto" @click="generateGridPrompt" :disabled="gridPromptLoading">
                       <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
                       重新生成
@@ -1170,6 +1190,7 @@
                   </div>
                   <div class="grid-tool-foot">
                     <button class="btn" @click="gridStep = 1">返回</button>
+                    <button type="button" class="btn btn-sm" :disabled="uploading" @click="openLocalImageUpload({ kind: 'grid' })">替换为本地图片</button>
                     <button class="btn btn-primary ml-auto" @click="doGridSplit">
                       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
                       切分并分配
@@ -1221,7 +1242,7 @@
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
                   </div>
                   <span class="prod-idx">#{{ String(i+1).padStart(2,'0') }}</span>
-                  <span v-if="hasComposed(sb)" class="prod-overlay-badge">已合成</span>
+                  <span v-if="hasComposed(sb)" class="prod-overlay-badge prod-badge-composed-hint" title="此处预览的是「视频生成」的原始文件；另有合成成片时可在下方弃用">另有成片</span>
                 </div>
                 <div class="prod-info">
                   <div class="prod-desc truncate">{{ sb.description || sb.title || '—' }}</div>
@@ -1233,6 +1254,13 @@
                   <div v-if="videoFailMessage(sb.id)" class="prod-error">{{ videoFailMessage(sb.id) }}</div>
                 </div>
                 <div class="prod-actions">
+                  <button type="button" class="btn btn-sm btn-ghost" :disabled="uploading" @click="openLocalImageUpload({ kind: 'storyboard_frame', id: sb.id, frameType: 'composed' })">本地上传参考图</button>
+                  <button
+                    v-if="hasComposed(sb)"
+                    type="button"
+                    class="btn btn-sm btn-ghost"
+                    @click="clearComposedVideo(sb)"
+                  >弃用合成成片</button>
                   <button class="btn btn-sm" :disabled="isPendingVideo(sb.id)" @click="genVid(sb)">
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
                     {{ isPendingVideo(sb.id) ? '生成中' : '生成视频' }}
@@ -1296,6 +1324,14 @@
                   <div v-if="composeFailMessage(sb.id)" class="prod-error">{{ composeFailMessage(sb.id) }}</div>
                 </div>
                 <div class="prod-actions">
+                  <button type="button" class="btn btn-sm btn-ghost" :disabled="uploading" @click="openLocalImageUpload({ kind: 'storyboard_frame', id: sb.id, frameType: 'composed' })">本地上传参考图</button>
+                  <button
+                    v-if="hasComposed(sb)"
+                    type="button"
+                    class="btn btn-sm btn-ghost"
+                    :disabled="isPendingCompose(sb.id)"
+                    @click="clearComposedVideo(sb)"
+                  >弃用合成成片</button>
                   <button class="btn btn-sm" :disabled="!hasVid(sb) || isPendingCompose(sb.id)" @click="doCompose(sb)">
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
                     {{ isPendingCompose(sb.id) ? '合成中' : (hasComposed(sb) ? '重新合成' : '开始合成') }}
@@ -1330,6 +1366,10 @@
                   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                   下载视频
                 </a>
+                <NuxtLink :to="`/drama/${dramaId}/episode/${episodeNumber}/edit`" class="btn">简易剪辑</NuxtLink>
+                <button type="button" class="btn btn-ghost btn-sm" :disabled="mergeClearing" @click="clearMergeExport">
+                  {{ mergeClearing ? '清理中…' : '清除拼接记录与旧成片' }}
+                </button>
               </div>
             </template>
             <template v-else>
@@ -1338,10 +1378,25 @@
                   <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
                 </div>
                 <div class="empty-title">拼接全集视频</div>
-                <div class="empty-desc">将 {{ composedCount }} 个已合成镜头拼接为完整视频</div>
-                <button class="btn btn-primary" :disabled="composedCount === 0" @click="doMerge" style="margin-top:12px">
+                <div class="empty-desc">{{ mergeExportHint }}</div>
+                <button class="btn btn-primary" :disabled="!canMergeEpisode" @click="doMerge" style="margin-top:12px">
                   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
                   开始拼接
+                </button>
+                <NuxtLink
+                  v-if="canMergeEpisode"
+                  :to="`/drama/${dramaId}/episode/${episodeNumber}/edit`"
+                  class="btn"
+                  style="margin-top:10px"
+                >简易时间轴剪辑</NuxtLink>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-sm"
+                  style="margin-top:10px"
+                  :disabled="mergeClearing"
+                  @click="clearMergeExport"
+                >
+                  {{ mergeClearing ? '清理中…' : '清除历史拼接记录与旧成片' }}
                 </button>
               </div>
             </template>
@@ -1352,7 +1407,7 @@
               <div v-for="(sb, i) in sbs" :key="sb.id" class="exp-row">
                 <span class="mono dim" style="font-size:10px">#{{ String(i+1).padStart(2,'0') }}</span>
                 <span class="truncate" style="flex:1;font-size:11px">{{ sb.description || sb.title || '—' }}</span>
-                <span :class="['dot', hasComposed(sb) && 'ok']" />
+                <span :class="['dot', hasMergeClip(sb) && 'ok']" />
               </div>
             </div>
           </div>
@@ -1440,8 +1495,9 @@ import { toast } from 'vue-sonner'
 import {
   Users, MapPin, Video, ImageIcon, Layers, Mic2, FileText, FolderKanban, Clapperboard, Download,
 } from 'lucide-vue-next'
-import { dramaAPI, episodeAPI, storyboardAPI, characterAPI, sceneAPI, imageAPI, videoAPI, composeAPI, mergeAPI, gridAPI, aiConfigAPI, voicesAPI } from '~/composables/useApi'
+import { dramaAPI, episodeAPI, storyboardAPI, characterAPI, sceneAPI, imageAPI, videoAPI, composeAPI, mergeAPI, gridAPI, aiConfigAPI, voicesAPI, uploadImageFile } from '~/composables/useApi'
 import { useAgent } from '~/composables/useAgent'
+import { usePipelinePrefs } from '~/composables/usePipelinePrefs'
 import BaseSelect from '~/components/BaseSelect.vue'
 
 definePageMeta({ layout: 'studio' })
@@ -1451,8 +1507,10 @@ const dramaId = Number(route.params.id)
 const episodeNumber = Number(route.params.episodeNumber)
 
 const drama = ref(null), episode = ref(null), chars = ref([]), scenes = ref([]), sbs = ref([]), mergeData = ref(null)
+const mergeClearing = ref(false)
 const panel = ref('script')
 const { running: rn, runningType: rt, run: runAgent } = useAgent()
+const { skipVideoCompose } = usePipelinePrefs()
 
 const localRaw = ref(''), localScript = ref('')
 const rawContent = computed(() => episode.value?.content || '')
@@ -1467,6 +1525,9 @@ const mergeUrl = computed(() => mergeData.value?.merged_url || mergeData.value?.
 
 const scriptStep = ref(0)
 const prodTab = ref('chars')
+watch(skipVideoCompose, (skip) => {
+  if (skip && prodTab.value === 'compose') prodTab.value = 'videos'
+})
 const prodTabIdx = computed({
   get: () => prodTabDefs.value.findIndex(t => t.id === prodTab.value),
   set: (v) => { prodTab.value = prodTabDefs.value[v]?.id || 'chars' },
@@ -1506,6 +1567,61 @@ const pendingComposeIds = ref([])
 const failedVideoMessages = ref({})
 const failedComposeMessages = ref({})
 const imageViewer = ref({ open: false, src: '', title: '' })
+
+const uploadInputRef = ref(null)
+const uploadTarget = ref(null)
+const uploading = ref(false)
+
+function openLocalImageUpload(ctx) {
+  uploadTarget.value = ctx
+  nextTick(() => uploadInputRef.value?.click())
+}
+
+async function onLocalImageSelected(e) {
+  const file = e.target.files?.[0]
+  e.target.value = ''
+  if (!file || !uploadTarget.value) return
+  uploading.value = true
+  const ctx = uploadTarget.value
+  uploadTarget.value = null
+  try {
+    const { path } = await uploadImageFile(file)
+    if (ctx.kind === 'character') {
+      await characterAPI.update(ctx.id, { image_url: path })
+      pendingCharImageIds.value = pendingCharImageIds.value.filter(x => x !== ctx.id)
+    } else if (ctx.kind === 'scene') {
+      await sceneAPI.update(ctx.id, { image_url: path, status: 'completed' })
+      pendingSceneImageIds.value = pendingSceneImageIds.value.filter(x => x !== ctx.id)
+    } else if (ctx.kind === 'storyboard_frame') {
+      const field = ctx.frameType === 'first_frame' ? 'first_frame_image'
+        : ctx.frameType === 'last_frame' ? 'last_frame_image'
+        : 'composed_image'
+      await storyboardAPI.update(ctx.id, { [field]: path })
+      if (ctx.frameType === 'first_frame' || ctx.frameType === 'last_frame') {
+        const k = framePendingKey(ctx.id, ctx.frameType)
+        pendingShotFrameKeys.value = pendingShotFrameKeys.value.filter(item => item !== k)
+      }
+    } else if (ctx.kind === 'grid') {
+      gridImagePath.value = path
+      gridGenId.value = null
+      const { rows, cols } = gridLayoutShape.value
+      gridActualLayout.value = { rows, cols }
+      if (!gridAssignmentsState.value.length) resetGridAssignments()
+      persistGridImagePath(path)
+      gridDialog.value = true
+      gridStep.value = 3
+      toast.success('已载入本地宫格图，可在预览中切分分配')
+      await refresh()
+      return
+    }
+    toast.success('已使用本地图片')
+    await refresh()
+  } catch (err) {
+    toast.error(err?.message || '上传失败')
+  } finally {
+    uploading.value = false
+  }
+}
 
 function configLabel(config) {
   if (!config) return '未配置'
@@ -1758,10 +1874,18 @@ function prodStepDone(id) {
   if (id === 'dubbing') return !!sbs.value.length && (!ttsEligibleCount.value || ttsGeneratedCount.value === ttsEligibleCount.value)
   if (id === 'shots') return !!sbs.value.length && shotImgCount.value === sbs.value.length
   if (id === 'videos') return !!sbs.value.length && shotVidCount.value === sbs.value.length
-  if (id === 'compose') return !!sbs.value.length && composedCount.value === sbs.value.length
+  // 视频合成可选：全部已合成，或全部已有生成视频即可跳过本步
+  if (id === 'compose') {
+    if (!sbs.value.length) return false
+    if (composedCount.value === sbs.value.length) return true
+    return shotVidCount.value === sbs.value.length
+  }
   return false
 }
-const canExport = computed(() => !!sbs.value.length && composedCount.value === sbs.value.length)
+const canExport = computed(() => {
+  if (!sbs.value.length) return false
+  return composedCount.value === sbs.value.length || shotVidCount.value === sbs.value.length
+})
 function goNextProd() {
   if (prodTabIdx.value < prodTabDefs.value.length - 1) {
     prodTabIdx.value++
@@ -2063,7 +2187,15 @@ async function doGridSplit() {
       toast.warning('请至少分配一个格子')
       return
     }
-    await gridAPI.split({ image_generation_id: gridGenId.value, rows, cols, assignments })
+    const splitPayload = { rows, cols, assignments }
+    const rawPath = (gridImagePath.value || '').replace(/^\//, '')
+    if (rawPath) splitPayload.local_path = rawPath
+    else if (gridGenId.value) splitPayload.image_generation_id = gridGenId.value
+    else {
+      toast.error('没有可切分的宫格图')
+      return
+    }
+    await gridAPI.split(splitPayload)
     persistGridImagePath(gridImagePath.value)
     gridStep.value = 4
     toast.success('切分分配完成')
@@ -2078,16 +2210,32 @@ const ttsEligibleCount = computed(() => sbs.value.filter(s => hasDialogue(s)).le
 const ttsGeneratedCount = computed(() => sbs.value.filter(s => hasDialogue(s) && hasTTS(s)).length)
 const shotImgCount = computed(() => sbs.value.filter(s => s.first_frame_image || s.firstFrameImage || s.last_frame_image || s.lastFrameImage || s.composed_image || s.composedImage).length)
 const shotVidCount = computed(() => sbs.value.filter(s => s.video_url || s.videoUrl).length)
+/** 每个镜头是否已有可拼接片源：已合成成片优先，否则已生成视频 */
+const mergeClipReadyCount = computed(() => sbs.value.filter(s => s.composed_video_url || s.composedVideoUrl || s.video_url || s.videoUrl).length)
+const canMergeEpisode = computed(() => !!sbs.value.length && mergeClipReadyCount.value === sbs.value.length)
+const mergeExportHint = computed(() => {
+  const n = sbs.value.length
+  if (!n) return '请先生成镜头视频'
+  const ready = mergeClipReadyCount.value
+  if (ready < n) return `需每个镜头都有视频（已合成或已生成）后才能拼接，当前 ${ready}/${n}`
+  if (composedCount.value === n) return `将 ${n} 个已合成镜头拼接为完整视频`
+  return `将 ${n} 个镜头视频拼接为完整视频（未做「视频合成」时将使用已生成视频）`
+})
 const visualCharTotal = computed(() => visualChars.value.length)
 
-const prodTabDefs = computed(() => [
-  { id: 'chars', label: '角色形象', icon: Users, badge: visualCharTotal.value ? `${charImgCount.value}/${visualCharTotal.value}` : '' },
-  { id: 'scenes', label: '场景图片', icon: MapPin, badge: sceneImgCount.value ? `${sceneImgCount.value}/${scenes.value.length}` : '' },
-  { id: 'dubbing', label: '配音生成', icon: Mic2, badge: '' },
-  { id: 'shots', label: '镜头图片', icon: ImageIcon, badge: shotImgCount.value ? `${shotImgCount.value}/${sbs.value.length}` : '' },
-  { id: 'videos', label: '视频生成', icon: Video, badge: shotVidCount.value ? `${shotVidCount.value}/${sbs.value.length}` : '' },
-  { id: 'compose', label: '视频合成', icon: Layers, badge: composedCount.value ? `${composedCount.value}/${sbs.value.length}` : '' },
-])
+const prodTabDefs = computed(() => {
+  const tabs = [
+    { id: 'chars', label: '角色形象', icon: Users, badge: visualCharTotal.value ? `${charImgCount.value}/${visualCharTotal.value}` : '' },
+    { id: 'scenes', label: '场景图片', icon: MapPin, badge: sceneImgCount.value ? `${sceneImgCount.value}/${scenes.value.length}` : '' },
+    { id: 'dubbing', label: '配音生成', icon: Mic2, badge: '' },
+    { id: 'shots', label: '镜头图片', icon: ImageIcon, badge: shotImgCount.value ? `${shotImgCount.value}/${sbs.value.length}` : '' },
+    { id: 'videos', label: '视频生成', icon: Video, badge: shotVidCount.value ? `${shotVidCount.value}/${sbs.value.length}` : '' },
+  ]
+  if (!skipVideoCompose.value) {
+    tabs.push({ id: 'compose', label: '视频合成', icon: Layers, badge: composedCount.value ? `${composedCount.value}/${sbs.value.length}` : '' })
+  }
+  return tabs
+})
 
 const mainStageDefs = [
   { id: 'script', label: '剧本', desc: '内容改写与整理', icon: FileText },
@@ -2096,38 +2244,39 @@ const mainStageDefs = [
   { id: 'export', label: '导出', desc: '拼接与成片输出', icon: Download },
 ]
 
-const sidebarSections = computed(() => ([
-  {
-    id: 'script',
-    label: '剧本',
-    items: [
-      { key: 'script:raw', label: '原始内容', desc: '', icon: FileText, done: !!rawContent.value },
-      { key: 'script:rewrite', label: 'AI 改写', desc: '', icon: FileText, done: !!scriptContent.value },
-      { key: 'script:extract', label: '提取', desc: '', icon: Users, done: !!chars.value.length },
-      { key: 'script:voice', label: '音色', desc: '', icon: Mic2, done: !!chars.value.length && charsVoiced.value === chars.value.length },
-      { key: 'script:storyboard', label: '分镜', desc: '', icon: Clapperboard, done: !!sbs.value.length },
-    ],
-  },
-  {
-    id: 'production',
-    label: '制作',
-    items: [
-      { key: 'prod:chars', label: '角色形象', desc: '', icon: Users, done: prodStepDone('chars') },
-      { key: 'prod:scenes', label: '场景图片', desc: '', icon: MapPin, done: prodStepDone('scenes') },
-      { key: 'prod:dubbing', label: '配音生成', desc: '', icon: Mic2, done: prodStepDone('dubbing') },
-      { key: 'prod:shots', label: '镜头图片', desc: '', icon: ImageIcon, done: prodStepDone('shots') },
-      { key: 'prod:videos', label: '视频生成', desc: '', icon: Video, done: prodStepDone('videos') },
-      { key: 'prod:compose', label: '视频合成', desc: '', icon: Layers, done: prodStepDone('compose') },
-    ],
-  },
-  {
-    id: 'export',
-    label: '导出',
-    items: [
-      { key: 'export:merge', label: '拼接导出', desc: '', icon: Download, done: !!mergeUrl.value },
-    ],
-  },
-]))
+const sidebarSections = computed(() => {
+  const prodItems = [
+    { key: 'prod:chars', label: '角色形象', desc: '', icon: Users, done: prodStepDone('chars') },
+    { key: 'prod:scenes', label: '场景图片', desc: '', icon: MapPin, done: prodStepDone('scenes') },
+    { key: 'prod:dubbing', label: '配音生成', desc: '', icon: Mic2, done: prodStepDone('dubbing') },
+    { key: 'prod:shots', label: '镜头图片', desc: '', icon: ImageIcon, done: prodStepDone('shots') },
+    { key: 'prod:videos', label: '视频生成', desc: '', icon: Video, done: prodStepDone('videos') },
+  ]
+  if (!skipVideoCompose.value) {
+    prodItems.push({ key: 'prod:compose', label: '视频合成', desc: '', icon: Layers, done: prodStepDone('compose') })
+  }
+  return [
+    {
+      id: 'script',
+      label: '剧本',
+      items: [
+        { key: 'script:raw', label: '原始内容', desc: '', icon: FileText, done: !!rawContent.value },
+        { key: 'script:rewrite', label: 'AI 改写', desc: '', icon: FileText, done: !!scriptContent.value },
+        { key: 'script:extract', label: '提取', desc: '', icon: Users, done: !!chars.value.length },
+        { key: 'script:voice', label: '音色', desc: '', icon: Mic2, done: !!chars.value.length && charsVoiced.value === chars.value.length },
+        { key: 'script:storyboard', label: '分镜', desc: '', icon: Clapperboard, done: !!sbs.value.length },
+      ],
+    },
+    { id: 'production', label: '制作', items: prodItems },
+    {
+      id: 'export',
+      label: '导出',
+      items: [
+        { key: 'export:merge', label: '拼接导出', desc: '', icon: Download, done: !!mergeUrl.value },
+      ],
+    },
+  ]
+})
 
 const activeMainStage = computed(() => {
   if (panel.value === 'export') return 'export'
@@ -2153,7 +2302,6 @@ function mainStageDone(stageId) {
     return ttsReady
       && shotImgCount.value === sbs.value.length
       && shotVidCount.value === sbs.value.length
-      && composedCount.value === sbs.value.length
   }
   if (stageId === 'export') return !!mergeUrl.value
   return false
@@ -2180,7 +2328,8 @@ function goMainStage(stageId) {
   }
   if (stageId === 'storyboard') {
     if (panel.value === 'production') {
-      prodTab.value = ['dubbing', 'shots', 'videos', 'compose'].includes(prodTab.value) ? prodTab.value : 'dubbing'
+      const storyTabs = skipVideoCompose.value ? ['dubbing', 'shots', 'videos'] : ['dubbing', 'shots', 'videos', 'compose']
+      prodTab.value = storyTabs.includes(prodTab.value) ? prodTab.value : 'dubbing'
       return
     }
     panel.value = 'script'
@@ -2206,13 +2355,16 @@ const activeSubSteps = computed(() => {
     ]
   }
   if (activeMainStage.value === 'storyboard') {
-    return [
+    const steps = [
       { key: 'script:storyboard', label: '分镜拆解', done: !!sbs.value.length },
       { key: 'prod:dubbing', label: '配音生成', done: !ttsEligibleCount.value || ttsGeneratedCount.value === ttsEligibleCount.value },
       { key: 'prod:shots', label: '镜头图片', done: !!sbs.value.length && shotImgCount.value === sbs.value.length },
       { key: 'prod:videos', label: '视频生成', done: !!sbs.value.length && shotVidCount.value === sbs.value.length },
-      { key: 'prod:compose', label: '视频合成', done: !!sbs.value.length && composedCount.value === sbs.value.length },
     ]
+    if (!skipVideoCompose.value) {
+      steps.push({ key: 'prod:compose', label: '视频合成', done: prodStepDone('compose') })
+    }
+    return steps
   }
   return [
     { key: 'export:merge', label: '拼接导出', done: !!mergeUrl.value },
@@ -2285,6 +2437,8 @@ function goSubStep(key) {
   panel.value = 'export'
 }
 
+const pipelineTotal = computed(() => (skipVideoCompose.value ? 10 : 11))
+
 const pipelineProgress = computed(() => {
   let p = 0
   if (rawContent.value) p++
@@ -2295,7 +2449,7 @@ const pipelineProgress = computed(() => {
   if (sbs.value.length && (!ttsEligibleCount.value || ttsGeneratedCount.value === ttsEligibleCount.value)) p++
   if (sbs.value.some(s => s.composed_image || s.composedImage)) p++
   if (sbs.value.some(s => s.video_url || s.videoUrl)) p++
-  if (sbs.value.length && composedCount.value === sbs.value.length) p++
+  if (sbs.value.length && (composedCount.value === sbs.value.length || shotVidCount.value === sbs.value.length)) p++
   if (mergeUrl.value) p++
   return p
 })
@@ -2615,6 +2769,7 @@ function getComposedVideoUrl(s) { return s?.composed_video_url || s?.composedVid
 function hasImg(s) { return !!getStoryboardCover(s) }
 function hasVid(s) { return !!getVideoUrl(s) }
 function hasComposed(s) { return !!getComposedVideoUrl(s) }
+function hasMergeClip(sb) { return !!(sb.composed_video_url || sb.composedVideoUrl || sb.video_url || sb.videoUrl) }
 
 function getShotReferenceImages(sb) {
   const refs = []
@@ -2761,6 +2916,25 @@ async function pollVideoGeneration(generationId, storyboardId) {
   }
   toast.error('视频生成超时')
 }
+async function clearComposedVideo(sb) {
+  if (!hasVid(sb)) {
+    toast.warning('没有可保留的生成视频时无法弃用合成成片')
+    return
+  }
+  if (!window.confirm('将删除该镜头的合成成片文件，并清空数据库中的成片记录；之后只使用「视频生成」的原始视频。确定？')) return
+  try {
+    await storyboardAPI.update(sb.id, { composed_video_url: null })
+    delete failedComposeMessages.value[sb.id]
+    sb.composed_video_url = null
+    sb.composedVideoUrl = null
+    if (String(sb.status || '').startsWith('compose_')) sb.status = null
+    await refresh()
+    toast.success('已恢复为仅使用生成视频')
+  } catch (e) {
+    toast.error(e?.message || '操作失败')
+  }
+}
+
 async function doCompose(sb) {
   try {
     delete failedComposeMessages.value[sb.id]
@@ -2809,6 +2983,27 @@ async function doMerge() {
       mergeData.value.status === 'completed' ? toast.success('拼接完成') : toast.error('拼接失败')
     }
   }, 3000)
+}
+
+async function clearMergeExport() {
+  if (!epId.value) return
+  const ok = window.confirm(
+    '将删除本集全部拼接记录，并删除服务器上 static/merged 里对应的成片文件；若本集在数据库里保存了该片地址，也会清空。确定执行？',
+  )
+  if (!ok) return
+  mergeClearing.value = true
+  try {
+    const r = await mergeAPI.clear(epId.value)
+    mergeData.value = null
+    await refresh()
+    const rows = r?.removed_rows ?? r?.removedRows ?? 0
+    const files = r?.removed_files ?? r?.removedFiles ?? 0
+    toast.success(`已清理：${rows} 条记录，${files} 个成片文件`)
+  } catch (e) {
+    toast.error(e?.message || '清理失败')
+  } finally {
+    mergeClearing.value = false
+  }
 }
 
 async function pollComposeStatus() {
@@ -3657,6 +3852,45 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 .asset-name { font-size: 13px; font-weight: 600; }
 .asset-meta { font-size: 11px; }
 .asset-foot { display: flex; align-items: center; gap: 4px; padding: 6px 10px; border-top: 1px solid var(--border); }
+.asset-foot-actions { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+
+.detail-preview-upload {
+  margin-top: 6px;
+  width: 100%;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 8px;
+  border: 1px solid rgba(27, 41, 64, 0.12);
+  background: rgba(255,255,255,0.9);
+  color: var(--text-2);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.detail-preview-upload:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.detail-preview-upload:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.frame-thumb-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  width: 130px;
+}
+.frame-thumb-upload {
+  padding: 1px 6px;
+  font-size: 9px;
+  font-weight: 700;
+  border-radius: 6px;
+  border: 1px solid rgba(27, 41, 64, 0.12);
+  background: rgba(255,255,255,0.92);
+  color: var(--text-2);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.frame-thumb-upload:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.frame-thumb-upload:disabled { opacity: 0.4; cursor: not-allowed; }
+.frame-composed-upload { margin-top: 6px; padding-left: 2px; }
 
 /* Frame grid */
 .frame-grid { display: flex; flex-direction: column; gap: 8px; }
@@ -3739,6 +3973,10 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
   position: absolute; bottom: 5px; right: 5px; font-size: 10px; font-weight: 600;
   background: var(--success); color: #fff; padding: 1px 5px; border-radius: 3px;
 }
+.prod-badge-composed-hint {
+  background: rgba(90, 100, 120, 0.88);
+  font-weight: 500;
+}
 .prod-info { padding: 10px 12px 8px; }
 .prod-desc { font-size: 12px; line-height: 1.4; }
 .prod-meta-line { margin-top: 5px; font-size: 10px; color: var(--text-3); }
@@ -3749,8 +3987,9 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
   line-height: 1.45;
   color: var(--error);
 }
-.prod-actions { display: flex; gap: 6px; padding: 8px 10px 10px; border-top: 1px solid rgba(27, 41, 64, 0.08); }
-.prod-actions .btn { flex: 1; justify-content: center; }
+.prod-actions { display: flex; gap: 6px; padding: 8px 10px 10px; border-top: 1px solid rgba(27, 41, 64, 0.08); flex-wrap: wrap; }
+.prod-actions .btn { flex: 1; justify-content: center; min-width: 0; }
+.prod-actions .btn.btn-ghost { flex: 0 1 auto; }
 
 /* Image viewer */
 .image-viewer-overlay {
@@ -4140,7 +4379,7 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 .export-split { flex: 1; display: flex; min-height: 0; }
 .export-main { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 32px; }
 .export-video { max-width: 720px; width: 100%; border-radius: var(--radius-lg); background: #000; }
-.export-bar { display: flex; align-items: center; gap: 12px; margin-top: 16px; width: 100%; max-width: 720px; }
+.export-bar { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-top: 16px; width: 100%; max-width: 720px; }
 .export-list { width: 240px; flex-shrink: 0; border-left: 1px solid var(--border); display: flex; flex-direction: column; overflow: hidden; }
 .export-list-head { padding: 11px 14px; font-size: 11px; font-weight: 700; color: var(--text-3); border-bottom: 1px solid var(--border); text-transform: uppercase; letter-spacing: 0.06em; }
 .export-list-body { flex: 1; overflow-y: auto; padding: 6px; }

--- a/frontend/app/pages/drama/[id]/episode/[episodeNumber]/index.vue
+++ b/frontend/app/pages/drama/[id]/episode/[episodeNumber]/index.vue
@@ -291,9 +291,10 @@
                 <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/></svg>
                 重新分配
               </button>
-              <button v-if="charsVoiced" class="btn btn-sm" @click="batchGenSamples">
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19 5v14"/></svg>
-                生成试听文件
+              <button v-if="charsVoiced" class="btn btn-sm" :disabled="batchVoiceSamplesBusy" @click="batchGenSamples">
+                <Loader2 v-if="batchVoiceSamplesBusy" :size="11" class="animate-spin" />
+                <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19 5v14"/></svg>
+                {{ batchVoiceSamplesBusy ? '生成中…' : '生成试听文件' }}
               </button>
             </div>
           </div>
@@ -385,9 +386,10 @@
                 </div>
 
                 <div class="voice-actions-row">
-                  <button class="btn btn-sm" :disabled="!(c.voice_style || c.voiceStyle)" @click="genSample(c.id)">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>
-                    {{ (c.voice_sample_url || c.voiceSampleUrl) ? '重新试听' : '生成试听' }}
+                  <button class="btn btn-sm" :disabled="!(c.voice_style || c.voiceStyle) || generatingVoiceCharId === c.id" @click="genSample(c.id)">
+                    <Loader2 v-if="generatingVoiceCharId === c.id" :size="12" class="animate-spin" />
+                    <svg v-else width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/></svg>
+                    {{ generatingVoiceCharId === c.id ? '生成中…' : ((c.voice_sample_url || c.voiceSampleUrl) ? '重新试听' : '生成试听') }}
                   </button>
                   <span class="dim" style="font-size:11px">{{ (c.voice_sample_url || c.voiceSampleUrl) ? '已生成声音样本，可直接播放' : '生成后可快速确认角色声音' }}</span>
                 </div>
@@ -660,6 +662,23 @@
                     <textarea :value="selectedSb.image_prompt || selectedSb.imagePrompt || ''" class="textarea" rows="4"
                       @blur="updateField(selectedSb, 'image_prompt', $event.target.value)" placeholder="用于首帧、尾帧和镜头图片的单帧画面提示词" />
                   </label>
+                  <div class="field user-ref-field">
+                    <span class="field-label">多模态参考图（可选）</span>
+                    <p class="user-ref-hint">本镜头参考图会与角色/场景资料卡上的参考图、立绘与场景成图、首尾帧等一并送入图片模型（合计最多 6 张）。角色、场景卡在制作页资料卡里单独维护参考图。</p>
+                    <div class="user-ref-thumbs">
+                      <div v-for="(p, ri) in getRefs(selectedSb)" :key="ri + p" class="user-ref-thumb">
+                        <img :src="'/' + p.replace(/^\//, '')" alt="" @click="openImageViewer('/' + p.replace(/^\//, ''), '参考图')" />
+                        <button type="button" class="user-ref-remove" :disabled="uploading" title="移除" @click="removeUserReferenceImage(selectedSb, ri)">×</button>
+                      </div>
+                      <button
+                        v-if="getRefs(selectedSb).length < 6"
+                        type="button"
+                        class="user-ref-add"
+                        :disabled="uploading"
+                        @click="openUserReferenceUpload(selectedSb)"
+                      >+ 上传</button>
+                    </div>
+                  </div>
                   <label class="field">
                     <span class="field-label">视频提示词</span>
                     <textarea :value="selectedSb.video_prompt || selectedSb.videoPrompt || ''" class="textarea" rows="5"
@@ -747,9 +766,10 @@
               <span class="tag">{{ lockedImageConfigLabel }}</span>
               <span v-if="chars.length > visualChars.length" class="tag">旁白仅保留声音</span>
               <div class="ml-auto flex gap-1">
-                <button class="btn btn-sm" @click="batchCharImages">
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-                  批量生成
+                <button class="btn btn-sm" :disabled="batchCharImagesBusy" @click="batchCharImages">
+                  <Loader2 v-if="batchCharImagesBusy" :size="11" class="animate-spin" />
+                  <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+                  {{ batchCharImagesBusy ? '生成中…' : '批量生成' }}
                 </button>
               </div>
             </div>
@@ -771,12 +791,34 @@
                   <div class="asset-name">{{ c.name }}</div>
                   <div class="asset-meta dim">{{ c.role || '角色' }}</div>
                 </div>
+                <div class="asset-refs asset-refs--card" @click.stop>
+                  <span class="asset-refs-label dim">参考图</span>
+                  <div class="user-ref-thumbs user-ref-thumbs--compact">
+                    <div v-for="(p, ri) in getCharRefs(c)" :key="'cref-' + c.id + '-' + ri + p" class="user-ref-thumb">
+                      <img :src="'/' + p.replace(/^\//, '')" alt="" @click.stop="openImageViewer('/' + p.replace(/^\//, ''), '参考图')" />
+                      <button type="button" class="user-ref-remove" :disabled="uploading" title="移除" @click.stop="removeCharReferenceImage(c, ri)">×</button>
+                    </div>
+                    <button
+                      v-if="getCharRefs(c).length < MAX_USER_REFERENCE_IMAGES"
+                      type="button"
+                      class="user-ref-add"
+                      :disabled="uploading || isPendingCharImage(c.id)"
+                      @click.stop="openCharReferenceUpload(c)"
+                    >+</button>
+                  </div>
+                </div>
                 <div class="asset-foot">
                   <span :class="['dot', (c.image_url || c.imageUrl) && 'ok', isPendingCharImage(c.id) && 'pending']" />
                   <span class="dim" style="font-size:10px">{{ (c.image_url || c.imageUrl) ? '已生成' : (isPendingCharImage(c.id) ? '生成中' : '待生成') }}</span>
                   <div class="asset-foot-actions ml-auto">
                     <button type="button" class="btn btn-sm btn-ghost" :disabled="uploading || isPendingCharImage(c.id)" @click="openLocalImageUpload({ kind: 'character', id: c.id })">本地上传</button>
-                    <button class="btn btn-sm" :disabled="isPendingCharImage(c.id)" @click="genCharImg(c.id)">{{ isPendingCharImage(c.id) ? '生成中' : '生成' }}</button>
+                    <button type="button" class="btn btn-sm btn-ghost btn-icon" title="立绘提示词" :disabled="isPendingCharImage(c.id)" @click="openCardCharPrompt(c)">
+                      <Settings :size="14" stroke-width="2" />
+                    </button>
+                    <button class="btn btn-sm" :disabled="isPendingCharImage(c.id)" @click="genCharImg(c.id)">
+                      <Loader2 v-if="isPendingCharImage(c.id)" :size="11" class="animate-spin" />
+                      {{ isPendingCharImage(c.id) ? '生成中…' : '生成' }}
+                    </button>
                   </div>
                 </div>
               </div>
@@ -789,9 +831,10 @@
               <span class="dim" style="font-size:12px">{{ scenes.length }} 个场景</span>
               <span class="tag">{{ lockedImageConfigLabel }}</span>
               <div class="ml-auto flex gap-1">
-                <button class="btn btn-sm" @click="batchSceneImages">
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-                  批量生成
+                <button class="btn btn-sm" :disabled="batchSceneImagesBusy" @click="batchSceneImages">
+                  <Loader2 v-if="batchSceneImagesBusy" :size="11" class="animate-spin" />
+                  <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+                  {{ batchSceneImagesBusy ? '生成中…' : '批量生成' }}
                 </button>
               </div>
             </div>
@@ -813,12 +856,34 @@
                   <div class="asset-name">{{ s.location }}</div>
                   <div class="asset-meta dim">{{ s.time || '—' }}</div>
                 </div>
+                <div class="asset-refs asset-refs--card" @click.stop>
+                  <span class="asset-refs-label dim">参考图</span>
+                  <div class="user-ref-thumbs user-ref-thumbs--compact">
+                    <div v-for="(p, ri) in getSceneRefs(s)" :key="'sref-' + s.id + '-' + ri + p" class="user-ref-thumb">
+                      <img :src="'/' + p.replace(/^\//, '')" alt="" @click.stop="openImageViewer('/' + p.replace(/^\//, ''), '参考图')" />
+                      <button type="button" class="user-ref-remove" :disabled="uploading" title="移除" @click.stop="removeSceneReferenceImage(s, ri)">×</button>
+                    </div>
+                    <button
+                      v-if="getSceneRefs(s).length < MAX_USER_REFERENCE_IMAGES"
+                      type="button"
+                      class="user-ref-add"
+                      :disabled="uploading || isPendingSceneImage(s.id)"
+                      @click.stop="openSceneReferenceUpload(s)"
+                    >+</button>
+                  </div>
+                </div>
                 <div class="asset-foot">
                   <span :class="['dot', (s.image_url || s.imageUrl) && 'ok', isPendingSceneImage(s.id) && 'pending']" />
                   <span class="dim" style="font-size:10px">{{ (s.image_url || s.imageUrl) ? '已生成' : (isPendingSceneImage(s.id) ? '生成中' : '待生成') }}</span>
                   <div class="asset-foot-actions ml-auto">
                     <button type="button" class="btn btn-sm btn-ghost" :disabled="uploading || isPendingSceneImage(s.id)" @click="openLocalImageUpload({ kind: 'scene', id: s.id })">本地上传</button>
-                    <button class="btn btn-sm" :disabled="isPendingSceneImage(s.id)" @click="genSceneImg(s.id)">{{ isPendingSceneImage(s.id) ? '生成中' : '生成' }}</button>
+                    <button type="button" class="btn btn-sm btn-ghost btn-icon" title="场景图提示词" :disabled="isPendingSceneImage(s.id)" @click="openCardScenePrompt(s)">
+                      <Settings :size="14" stroke-width="2" />
+                    </button>
+                    <button class="btn btn-sm" :disabled="isPendingSceneImage(s.id)" @click="genSceneImg(s.id)">
+                      <Loader2 v-if="isPendingSceneImage(s.id)" :size="11" class="animate-spin" />
+                      {{ isPendingSceneImage(s.id) ? '生成中…' : '生成' }}
+                    </button>
                   </div>
                 </div>
               </div>
@@ -832,9 +897,10 @@
               <span class="tag mono">{{ ttsGeneratedCount }}/{{ ttsEligibleCount }} 已生成</span>
               <span class="tag">{{ lockedAudioConfigLabel }}</span>
               <div class="ml-auto flex gap-1">
-                <button class="btn btn-sm" @click="batchShotTTS">
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/></svg>
-                  批量生成
+                <button class="btn btn-sm" :disabled="batchShotTtsBusy" @click="batchShotTTS">
+                  <Loader2 v-if="batchShotTtsBusy" :size="11" class="animate-spin" />
+                  <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/></svg>
+                  {{ batchShotTtsBusy ? '生成中…' : '批量生成' }}
                 </button>
               </div>
             </div>
@@ -867,7 +933,10 @@
                 <div class="dub-foot">
                   <audio v-if="hasTTS(sb)" :src="'/' + getTTSUrl(sb)" controls preload="none" class="dub-audio" />
                   <div v-else class="dim" style="font-size:12px">尚未生成语音文件</div>
-                  <button class="btn btn-sm ml-auto" @click="genShotTTS(sb)">生成配音</button>
+                  <button class="btn btn-sm ml-auto" :disabled="pendingTtsShotId === sb.id" @click="genShotTTS(sb)">
+                    <Loader2 v-if="pendingTtsShotId === sb.id" :size="11" class="animate-spin" />
+                    {{ pendingTtsShotId === sb.id ? '生成中…' : '生成配音' }}
+                  </button>
                 </div>
               </div>
             </div>
@@ -1011,6 +1080,22 @@
                       </div>
                     </div>
                   </div>
+                  <div class="frame-refs-row" @click.stop>
+                    <span class="frame-refs-label dim">参考图</span>
+                    <div class="user-ref-thumbs user-ref-thumbs--compact">
+                      <div v-for="(p, ri) in getRefs(sb)" :key="'fref-' + sb.id + '-' + ri + p" class="user-ref-thumb">
+                        <img :src="'/' + p.replace(/^\//, '')" alt="" @click.stop="openImageViewer('/' + p.replace(/^\//, ''), '参考图')" />
+                        <button type="button" class="user-ref-remove" :disabled="uploading" title="移除" @click.stop="removeUserReferenceImage(sb, ri)">×</button>
+                      </div>
+                      <button
+                        v-if="getRefs(sb).length < MAX_USER_REFERENCE_IMAGES"
+                        type="button"
+                        class="user-ref-add"
+                        :disabled="uploading"
+                        @click.stop="openUserReferenceUpload(sb)"
+                      >+</button>
+                    </div>
+                  </div>
                   <div class="frame-composed-upload">
                     <button type="button" class="btn btn-xs btn-ghost" :disabled="uploading" @click.stop="openLocalImageUpload({ kind: 'storyboard_frame', id: sb.id, frameType: 'composed' })">上传镜头图（合成参考）</button>
                   </div>
@@ -1085,7 +1170,7 @@
                       宫格图提示词
                       <span v-if="gridPromptSource" class="tag ml-8">{{ gridPromptSource === 'agent' ? 'AI生成' : '模板兜底' }}</span>
                     </div>
-                    <div class="grid-prompt-text">{{ gridPromptText || '（等待生成）' }}</div>
+                    <textarea v-model="gridPromptText" class="textarea grid-prompt-edit" rows="10" placeholder="可在此直接编辑整图提示词，再点「生成宫格图」" />
                   </div>
 
                   <div class="grid-blank-preview" :style="gridBlankStyle">
@@ -1103,8 +1188,9 @@
                     <button class="btn" @click="gridStep = 0">上一步</button>
                     <button type="button" class="btn btn-sm" :disabled="uploading" @click="openLocalImageUpload({ kind: 'grid' })">上传本地宫格图</button>
                     <button class="btn ml-auto" @click="generateGridPrompt" :disabled="gridPromptLoading">
-                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-                      重新生成
+                      <Loader2 v-if="gridPromptLoading" :size="11" class="animate-spin" />
+                      <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+                      {{ gridPromptLoading ? '生成中…' : '重新生成' }}
                     </button>
                     <button class="btn btn-primary" @click="startGridGen">
                       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
@@ -1215,9 +1301,10 @@
               <span class="dim" style="font-size:12px">{{ sbs.length }} 个镜头</span>
               <span class="tag mono">{{ shotVidCount }}/{{ sbs.length }} 已生成</span>
               <div class="ml-auto flex gap-1">
-                <button class="btn btn-sm" @click="batchVideos">
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-                  批量视频
+                <button class="btn btn-sm" :disabled="batchVideosBusy" @click="batchVideos">
+                  <Loader2 v-if="batchVideosBusy" :size="11" class="animate-spin" />
+                  <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+                  {{ batchVideosBusy ? '生成中…' : '批量视频' }}
                 </button>
               </div>
             </div>
@@ -1262,8 +1349,9 @@
                     @click="clearComposedVideo(sb)"
                   >弃用合成成片</button>
                   <button class="btn btn-sm" :disabled="isPendingVideo(sb.id)" @click="genVid(sb)">
-                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
-                    {{ isPendingVideo(sb.id) ? '生成中' : '生成视频' }}
+                    <Loader2 v-if="isPendingVideo(sb.id)" :size="11" class="animate-spin" />
+                    <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polygon points="23 7 16 12 23 17 23 7"/><rect x="1" y="5" width="15" height="14" rx="2" ry="2"/></svg>
+                    {{ isPendingVideo(sb.id) ? '生成中…' : '生成视频' }}
                   </button>
                 </div>
               </div>
@@ -1276,9 +1364,10 @@
               <span class="dim" style="font-size:12px">{{ sbs.length }} 个镜头</span>
               <span class="tag mono">{{ composedCount }}/{{ sbs.length }} 已合成</span>
               <div class="ml-auto flex gap-1">
-                <button class="btn btn-sm" @click="batchCompose">
-                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-                  批量合成
+                <button class="btn btn-sm" :disabled="batchComposeBusy" @click="batchCompose">
+                  <Loader2 v-if="batchComposeBusy" :size="11" class="animate-spin" />
+                  <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                  {{ batchComposeBusy ? '合成中…' : '批量合成' }}
                 </button>
               </div>
             </div>
@@ -1333,8 +1422,9 @@
                     @click="clearComposedVideo(sb)"
                   >弃用合成成片</button>
                   <button class="btn btn-sm" :disabled="!hasVid(sb) || isPendingCompose(sb.id)" @click="doCompose(sb)">
-                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-                    {{ isPendingCompose(sb.id) ? '合成中' : (hasComposed(sb) ? '重新合成' : '开始合成') }}
+                    <Loader2 v-if="isPendingCompose(sb.id)" :size="11" class="animate-spin" />
+                    <svg v-else width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                    {{ isPendingCompose(sb.id) ? '合成中…' : (hasComposed(sb) ? '重新合成' : '开始合成') }}
                   </button>
                 </div>
               </div>
@@ -1379,9 +1469,10 @@
                 </div>
                 <div class="empty-title">拼接全集视频</div>
                 <div class="empty-desc">{{ mergeExportHint }}</div>
-                <button class="btn btn-primary" :disabled="!canMergeEpisode" @click="doMerge" style="margin-top:12px">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-                  开始拼接
+                <button class="btn btn-primary" :disabled="!canMergeEpisode || mergeMerging" @click="doMerge" style="margin-top:12px">
+                  <Loader2 v-if="mergeMerging" :size="13" class="animate-spin" />
+                  <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+                  {{ mergeMerging ? '拼接中…' : '开始拼接' }}
                 </button>
                 <NuxtLink
                   v-if="canMergeEpisode"
@@ -1486,6 +1577,26 @@
         </div>
       </div>
     </main>
+
+    <Teleport to="body">
+      <div v-if="cardPromptOpen" class="overlay prompt-gear-overlay" @click.self="closeCardPrompt">
+        <div class="prompt-gear-dialog card card-prompt-dialog" role="dialog" aria-modal="true" aria-labelledby="card-prompt-dialog-title">
+          <div class="prompt-gear-head">
+            <h3 id="card-prompt-dialog-title" class="prompt-gear-title">{{ cardPromptTitle }}</h3>
+            <button type="button" class="btn btn-ghost btn-icon" title="关闭 (Esc)" aria-label="关闭" @click="closeCardPrompt">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            </button>
+          </div>
+          <p class="prompt-gear-sub">{{ cardPromptHint }}</p>
+          <label class="prompt-gear-label" for="card-prompt-textarea">生图提示词</label>
+          <textarea id="card-prompt-textarea" v-model="cardPromptDraft" class="textarea prompt-gear-textarea" rows="8" placeholder="编辑后点保存，再点卡片上的「生成」" />
+          <div class="card-prompt-foot">
+            <button type="button" class="btn btn-ghost" @click="closeCardPrompt">取消</button>
+            <button type="button" class="btn btn-primary" :disabled="cardPromptSaving" @click="saveCardPrompt">{{ cardPromptSaving ? '保存中…' : '保存' }}</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
     </div>
   </div>
 </template>
@@ -1493,7 +1604,7 @@
 <script setup>
 import { toast } from 'vue-sonner'
 import {
-  Users, MapPin, Video, ImageIcon, Layers, Mic2, FileText, FolderKanban, Clapperboard, Download,
+  Users, MapPin, Video, ImageIcon, Layers, Mic2, FileText, FolderKanban, Clapperboard, Download, Settings,
 } from 'lucide-vue-next'
 import { dramaAPI, episodeAPI, storyboardAPI, characterAPI, sceneAPI, imageAPI, videoAPI, composeAPI, mergeAPI, gridAPI, aiConfigAPI, voicesAPI, uploadImageFile } from '~/composables/useApi'
 import { useAgent } from '~/composables/useAgent'
@@ -1561,6 +1672,15 @@ const videoConfigs = ref([])
 const audioConfigs = ref([])
 const pendingCharImageIds = ref([])
 const pendingSceneImageIds = ref([])
+const batchCharImagesBusy = ref(false)
+const batchSceneImagesBusy = ref(false)
+const generatingVoiceCharId = ref(null)
+const pendingTtsShotId = ref(null)
+const batchVoiceSamplesBusy = ref(false)
+const batchShotTtsBusy = ref(false)
+const mergeMerging = ref(false)
+const batchComposeBusy = ref(false)
+const batchVideosBusy = ref(false)
 const pendingShotFrameKeys = ref([])
 const pendingVideoIds = ref([])
 const pendingComposeIds = ref([])
@@ -1589,9 +1709,54 @@ async function onLocalImageSelected(e) {
     if (ctx.kind === 'character') {
       await characterAPI.update(ctx.id, { image_url: path })
       pendingCharImageIds.value = pendingCharImageIds.value.filter(x => x !== ctx.id)
+    } else if (ctx.kind === 'character_reference') {
+      const c = chars.value.find(ch => ch.id === ctx.id)
+      if (!c) {
+        toast.error('找不到角色')
+        return
+      }
+      const list = [...getCharRefs(c)]
+      if (list.length >= MAX_USER_REFERENCE_IMAGES) {
+        toast.warning(`参考图最多 ${MAX_USER_REFERENCE_IMAGES} 张`)
+        return
+      }
+      list.push(path)
+      await persistCharReferenceImages(c, list)
+      toast.success('已添加参考图，生成立绘时将一并送入模型')
+      return
+    } else if (ctx.kind === 'scene_reference') {
+      const s = scenes.value.find(sc => sc.id === ctx.id)
+      if (!s) {
+        toast.error('找不到场景')
+        return
+      }
+      const list = [...getSceneRefs(s)]
+      if (list.length >= MAX_USER_REFERENCE_IMAGES) {
+        toast.warning(`参考图最多 ${MAX_USER_REFERENCE_IMAGES} 张`)
+        return
+      }
+      list.push(path)
+      await persistSceneReferenceImages(s, list)
+      toast.success('已添加参考图，生成场景图时将一并送入模型')
+      return
     } else if (ctx.kind === 'scene') {
       await sceneAPI.update(ctx.id, { image_url: path, status: 'completed' })
       pendingSceneImageIds.value = pendingSceneImageIds.value.filter(x => x !== ctx.id)
+    } else if (ctx.kind === 'storyboard_reference') {
+      const sb = sbs.value.find(s => s.id === ctx.id)
+      if (!sb) {
+        toast.error('找不到对应镜头')
+        return
+      }
+      const list = [...getRefs(sb)]
+      if (list.length >= MAX_USER_REFERENCE_IMAGES) {
+        toast.warning(`参考图最多 ${MAX_USER_REFERENCE_IMAGES} 张`)
+        return
+      }
+      list.push(path)
+      await persistStoryboardReferenceImages(sb, list)
+      toast.success('已添加参考图，生首/尾帧时将一并送入模型')
+      return
     } else if (ctx.kind === 'storyboard_frame') {
       const field = ctx.frameType === 'first_frame' ? 'first_frame_image'
         : ctx.frameType === 'last_frame' ? 'last_frame_image'
@@ -2058,6 +2223,7 @@ async function generateGridPrompt() {
       resetGridAssignments()
       gridPromptStatus.value = gridPromptSource.value === 'agent' ? 'AI 提示词已生成' : '已使用模板提示词'
       gridStep.value = 1
+      toast.success('宫格提示词成功生成')
     } else {
       gridPromptStatus.value = ''
       toast.error('提示词生成失败')
@@ -2084,13 +2250,14 @@ async function startGridGen() {
   gridStep.value = 2
   gridStatusText.value = '提交生成请求...'
   try {
+    const customPrompt = gridPromptText.value?.trim() || undefined
     const res = await gridAPI.generate({
       storyboard_ids: ids,
       drama_id: dramaId,
       rows,
       cols,
       mode: gridMode.value,
-      custom_prompt: gridPromptText.value || undefined,
+      custom_prompt: customPrompt,
     })
     gridGenId.value = res.image_generation_id
     gridActualLayout.value = res.grid || { rows, cols }
@@ -2113,6 +2280,7 @@ async function pollGridStatus() {
         gridGenId.value = gridGenId.value || res.id || null
         persistGridImagePath(res.local_path)
         gridStep.value = 3
+        toast.success('宫格图成功生成')
         return
       }
       if (res.status === 'failed') {
@@ -2613,32 +2781,54 @@ async function batchGenSamples() {
     toast.info(charsVoiced.value ? '所有角色的试听文件已生成' : '请先分配音色')
     return
   }
-  const results = await Promise.allSettled(pending.map(c => characterAPI.voiceSample(c.id, epId.value)))
-  const okCount = results.filter(r => r.status === 'fulfilled').length
-  const failCount = results.length - okCount
-  if (okCount) toast.success(`已生成 ${okCount} 份试听文件`)
-  if (failCount) toast.error(`${failCount} 份试听文件生成失败`)
-  await refresh()
+  batchVoiceSamplesBusy.value = true
+  try {
+    const results = await Promise.allSettled(pending.map(c => characterAPI.voiceSample(c.id, epId.value)))
+    const okCount = results.filter(r => r.status === 'fulfilled').length
+    const failCount = results.length - okCount
+    if (okCount) toast.success(`试听成功生成（${okCount} 份）`)
+    if (failCount) toast.error(`${failCount} 份试听生成失败`)
+    await refresh()
+  } finally {
+    batchVoiceSamplesBusy.value = false
+  }
 }
 function doBreakdown() {
   const cfg = videoConfigs.value.find(c => c.id === lockedVideoConfigId.value)
   const label = cfg ? `${cfg.name} (${cfg.provider})` : '默认'
   runAgent('storyboard_breaker', `请拆解分镜并生成视频提示词。视频模型：${label}，请根据该模型的特性和时长限制生成合适的视频提示词。`, dramaId, epId.value, refresh)
 }
-async function genSample(id) { try { await characterAPI.voiceSample(id, epId.value); toast.success('试听已生成'); refresh() } catch (e) { toast.error(e.message) } }
+async function genSample(id) {
+  generatingVoiceCharId.value = id
+  try {
+    await characterAPI.voiceSample(id, epId.value)
+    toast.success('试听成功生成')
+    await refresh()
+  } catch (e) {
+    toast.error(e.message)
+  } finally {
+    generatingVoiceCharId.value = null
+  }
+}
 async function addShot() { await storyboardAPI.create({ episode_id: epId.value, storyboard_number: sbs.value.length + 1, title: `镜头${sbs.value.length + 1}`, duration: 10 }); refresh() }
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-function watchAsyncResult(check, attempts = 24, delay = 2500) {
+/** 轮询 check() 直至为 true 或达次数上限；onSettled(success) 在结束时调用，success 表示曾检测到完成 */
+function watchAsyncResult(check, attempts = 24, delay = 2500, onSettled) {
   void (async () => {
+    let success = false
     for (let i = 0; i < attempts; i++) {
       await sleep(delay)
       await refresh()
-      if (check()) return
+      if (check()) {
+        success = true
+        break
+      }
     }
+    if (typeof onSettled === 'function') onSettled(success)
   })()
 }
 
@@ -2646,13 +2836,15 @@ async function genCharImg(id) {
   try {
     if (!isPendingCharImage(id)) pendingCharImageIds.value.push(id)
     await characterAPI.generateImage(id, epId.value)
-    toast.success('角色图片生成中')
     await refresh()
     watchAsyncResult(() => {
       const char = chars.value.find(c => c.id === id)
       const done = !!(char?.image_url || char?.imageUrl)
       if (done) pendingCharImageIds.value = pendingCharImageIds.value.filter(item => item !== id)
       return done
+    }, 24, 2500, (success) => {
+      if (success) toast.success('角色立绘成功生成')
+      else toast.warning('立绘生成未完成或超时，请刷新查看')
     })
   } catch (e) {
     pendingCharImageIds.value = pendingCharImageIds.value.filter(item => item !== id)
@@ -2662,17 +2854,22 @@ async function genCharImg(id) {
 function batchCharImages() {
   const ids = visualChars.value.filter(c => !(c.image_url || c.imageUrl)).map(c => c.id)
   if (!ids.length) { toast.info('所有角色图片已生成'); return }
+  batchCharImagesBusy.value = true
   pendingCharImageIds.value = [...new Set([...pendingCharImageIds.value, ...ids])]
   characterAPI.batchImages(ids, epId.value).then(async () => {
-    toast.success('角色图片批量生成中')
     await refresh()
     watchAsyncResult(() => ids.every(id => {
       const char = chars.value.find(c => c.id === id)
       const done = !!(char?.image_url || char?.imageUrl)
       if (done) pendingCharImageIds.value = pendingCharImageIds.value.filter(item => item !== id)
       return done
-    }), 36)
+    }), 36, 2500, (success) => {
+      batchCharImagesBusy.value = false
+      if (success) toast.success(`角色立绘成功生成（${ids.length} 个）`)
+      else toast.warning('部分立绘可能仍在生成，请稍后刷新')
+    })
   }).catch(e => {
+    batchCharImagesBusy.value = false
     pendingCharImageIds.value = pendingCharImageIds.value.filter(item => !ids.includes(item))
     toast.error(e.message)
   })
@@ -2681,13 +2878,15 @@ async function genSceneImg(id) {
   try {
     if (!isPendingSceneImage(id)) pendingSceneImageIds.value.push(id)
     await sceneAPI.generateImage(id, epId.value)
-    toast.success('场景图片生成中')
     await refresh()
     watchAsyncResult(() => {
       const scene = scenes.value.find(s => s.id === id)
       const done = !!(scene?.image_url || scene?.imageUrl)
       if (done) pendingSceneImageIds.value = pendingSceneImageIds.value.filter(item => item !== id)
       return done
+    }, 24, 2500, (success) => {
+      if (success) toast.success('场景图成功生成')
+      else toast.warning('场景图生成未完成或超时，请刷新查看')
     })
   } catch (e) {
     pendingSceneImageIds.value = pendingSceneImageIds.value.filter(item => item !== id)
@@ -2697,15 +2896,19 @@ async function genSceneImg(id) {
 function batchSceneImages() {
   const ids = scenes.value.filter(s => !(s.image_url || s.imageUrl)).map(s => s.id)
   if (!ids.length) { toast.info('所有场景图片已生成'); return }
+  batchSceneImagesBusy.value = true
   pendingSceneImageIds.value = [...new Set([...pendingSceneImageIds.value, ...ids])]
   ids.forEach(id => { sceneAPI.generateImage(id, epId.value).then(() => refresh()).catch(e => toast.error(e.message)) })
-  toast.success('场景图片批量生成中')
   watchAsyncResult(() => ids.every(id => {
     const scene = scenes.value.find(s => s.id === id)
     const done = !!(scene?.image_url || scene?.imageUrl)
     if (done) pendingSceneImageIds.value = pendingSceneImageIds.value.filter(item => item !== id)
     return done
-  }), 36)
+  }), 36, 2500, (success) => {
+    batchSceneImagesBusy.value = false
+    if (success) toast.success(`场景图成功生成（${ids.length} 个）`)
+    else toast.warning('部分场景图可能仍在生成，请稍后刷新')
+  })
 }
 
 const IGNORE_TTS_SPEAKERS = /^(环境音|环境声|音效|效果音|sfx|sound ?effect|bgm|背景音|背景音乐|ambient)$/i
@@ -2741,11 +2944,16 @@ function getDialogueSpeaker(sb) {
   return speaker
 }
 async function genShotTTS(sb) {
+  pendingTtsShotId.value = sb.id
   try {
     await storyboardAPI.generateTTS(sb.id)
-    toast.success(`镜头 #${sb.storyboard_number || sb.storyboardNumber || sb.id} 配音已生成`)
+    toast.success(`镜头 #${sb.storyboard_number || sb.storyboardNumber || sb.id} 配音成功生成`)
     await refresh()
-  } catch (e) { toast.error(e.message) }
+  } catch (e) {
+    toast.error(e.message)
+  } finally {
+    pendingTtsShotId.value = null
+  }
 }
 async function batchShotTTS() {
   const pending = sbs.value.filter(sb => hasDialogue(sb) && !hasTTS(sb))
@@ -2753,12 +2961,17 @@ async function batchShotTTS() {
     toast.info(ttsEligibleCount.value ? '所有镜头配音已生成' : '当前没有可生成的对白或旁白')
     return
   }
-  const results = await Promise.allSettled(pending.map(sb => storyboardAPI.generateTTS(sb.id)))
-  const okCount = results.filter(r => r.status === 'fulfilled').length
-  const failCount = results.length - okCount
-  if (okCount) toast.success(`已生成 ${okCount} 条镜头配音`)
-  if (failCount) toast.error(`${failCount} 条镜头配音生成失败`)
-  await refresh()
+  batchShotTtsBusy.value = true
+  try {
+    const results = await Promise.allSettled(pending.map(sb => storyboardAPI.generateTTS(sb.id)))
+    const okCount = results.filter(r => r.status === 'fulfilled').length
+    const failCount = results.length - okCount
+    if (okCount) toast.success(`配音成功生成（${okCount} 条）`)
+    if (failCount) toast.error(`${failCount} 条配音生成失败`)
+    await refresh()
+  } finally {
+    batchShotTtsBusy.value = false
+  }
 }
 
 function getFirstFrame(s) { return s?.first_frame_image || s?.firstFrameImage || null }
@@ -2780,9 +2993,11 @@ function getShotReferenceImages(sb) {
   const sceneId = sb?.scene_id || sb?.sceneId
   const scene = scenes.value.find(item => item.id === sceneId)
   pushRef(scene?.image_url || scene?.imageUrl)
+  for (const ref of getSceneRefs(scene)) pushRef(ref)
   for (const charId of getStoryboardCharacterIds(sb)) {
     const char = chars.value.find(item => item.id === charId)
     pushRef(char?.image_url || char?.imageUrl)
+    for (const ref of getCharRefs(char)) pushRef(ref)
   }
   for (const ref of getRefs(sb)) {
     pushRef(ref)
@@ -2824,6 +3039,95 @@ function buildShotImagePrompt(sb, frameType) {
   ].filter(Boolean).join('；')
 }
 
+/** 资料卡齿轮：角色 / 场景各自独立的生图提示词 */
+const cardPromptOpen = ref(false)
+const cardPromptKind = ref('char')
+const cardPromptEntityId = ref(0)
+const cardPromptTitle = ref('')
+const cardPromptDraft = ref('')
+const cardPromptSaving = ref(false)
+const cardPromptHint = computed(() =>
+  cardPromptKind.value === 'char'
+    ? '每条角色单独保存到「立绘提示词」字段。留空并保存后，生图将按姓名与外貌自动拼装。'
+    : '写入该场景的 prompt 字段。留空并保存时，将按地点、时间与默认后缀拼装。',
+)
+
+function buildCharImagePromptForEditor(c) {
+  const custom = String(c.image_prompt || c.imagePrompt || '').trim()
+  if (custom) return custom
+  const name = c.name || ''
+  const look = c.appearance || c.description || '人物立绘'
+  return `${name}, ${look}, 高质量, 正面, 白色背景`
+}
+
+function buildSceneImagePromptForEditor(s) {
+  const p = String(s.prompt || '').trim()
+  if (p) return p
+  const loc = s.location || ''
+  const tm = s.time || ''
+  const base = [loc, tm].filter(Boolean).join(', ')
+  return base ? `${base}, 高质量场景, 电影感` : '高质量场景, 电影感'
+}
+
+function openCardCharPrompt(c) {
+  cardPromptKind.value = 'char'
+  cardPromptEntityId.value = c.id
+  cardPromptTitle.value = `${c.name} · 立绘提示词`
+  cardPromptDraft.value = buildCharImagePromptForEditor(c)
+  cardPromptOpen.value = true
+}
+
+function openCardScenePrompt(s) {
+  cardPromptKind.value = 'scene'
+  cardPromptEntityId.value = s.id
+  cardPromptTitle.value = `${s.location} · 场景图提示词`
+  cardPromptDraft.value = buildSceneImagePromptForEditor(s)
+  cardPromptOpen.value = true
+}
+
+function closeCardPrompt() {
+  cardPromptOpen.value = false
+}
+
+async function saveCardPrompt() {
+  const id = cardPromptEntityId.value
+  const draft = cardPromptDraft.value.trim()
+  cardPromptSaving.value = true
+  try {
+    if (cardPromptKind.value === 'char') {
+      await characterAPI.update(id, { image_prompt: draft.length ? draft : null })
+    } else {
+      await sceneAPI.update(id, { prompt: draft })
+    }
+    toast.success('已保存')
+    await refresh()
+    closeCardPrompt()
+  } catch (e) {
+    toast.error(e.message)
+  } finally {
+    cardPromptSaving.value = false
+  }
+}
+
+let cardPromptEscHandler = null
+watch(cardPromptOpen, (open) => {
+  if (!import.meta.client) return
+  if (cardPromptEscHandler) {
+    window.removeEventListener('keydown', cardPromptEscHandler)
+    cardPromptEscHandler = null
+  }
+  if (open) {
+    cardPromptEscHandler = (e) => {
+      if (e.key === 'Escape') closeCardPrompt()
+    }
+    window.addEventListener('keydown', cardPromptEscHandler)
+  }
+})
+
+onUnmounted(() => {
+  if (import.meta.client && cardPromptEscHandler) window.removeEventListener('keydown', cardPromptEscHandler)
+})
+
 async function genShotFrame(sb, frameType) {
   const prompt = buildShotImagePrompt(sb, frameType)
   const referenceImages = getShotReferenceImages(sb)
@@ -2838,13 +3142,15 @@ async function genShotFrame(sb, frameType) {
       reference_images: referenceImages.length ? referenceImages : undefined,
     }
     await imageAPI.generate(body)
-    toast.success(frameType === 'first_frame' ? '首帧生成中' : '尾帧生成中')
     await refresh()
     watchAsyncResult(() => {
       const target = sbs.value.find(s => s.id === sb.id)
       const done = frameType === 'first_frame' ? !!getFirstFrame(target) : !!getLastFrame(target)
       if (done) pendingShotFrameKeys.value = pendingShotFrameKeys.value.filter(item => item !== key)
       return done
+    }, 24, 2500, (success) => {
+      if (success) toast.success(frameType === 'first_frame' ? '首帧成功生成' : '尾帧成功生成')
+      else toast.warning('画面生成未完成或超时，请刷新查看')
     })
   } catch (e) {
     pendingShotFrameKeys.value = pendingShotFrameKeys.value.filter(item => item !== key)
@@ -2869,7 +3175,6 @@ async function genVid(sb) {
     delete failedVideoMessages.value[sb.id]
     if (!isPendingVideo(sb.id)) pendingVideoIds.value.push(sb.id)
     const generation = await videoAPI.generate(params)
-    toast.success('视频生成中')
     await refresh()
     pollVideoGeneration(generation?.id, sb.id)
   } catch (e) {
@@ -2884,7 +3189,14 @@ async function pollVideoGeneration(generationId, storyboardId) {
       const done = !!(target?.video_url || target?.videoUrl)
       if (done) pendingVideoIds.value = pendingVideoIds.value.filter(item => item !== storyboardId)
       return done
-    }, 60, 4000)
+    }, 60, 4000, (success) => {
+      if (success) {
+        delete failedVideoMessages.value[storyboardId]
+        toast.success('视频成功生成')
+      } else {
+        toast.warning('视频生成未完成或超时，请刷新查看')
+      }
+    })
     return
   }
   for (let i = 0; i < 120; i++) {
@@ -2895,7 +3207,7 @@ async function pollVideoGeneration(generationId, storyboardId) {
       if (res?.status === 'completed') {
         pendingVideoIds.value = pendingVideoIds.value.filter(item => item !== storyboardId)
         delete failedVideoMessages.value[storyboardId]
-        toast.success('视频生成完成')
+        toast.success('视频成功生成')
         return
       }
       if (res?.status === 'failed') {
@@ -2936,53 +3248,95 @@ async function clearComposedVideo(sb) {
 }
 
 async function doCompose(sb) {
+  const sbId = sb.id
   try {
-    delete failedComposeMessages.value[sb.id]
-    if (!isPendingCompose(sb.id)) pendingComposeIds.value.push(sb.id)
-    await composeAPI.shot(sb.id)
-    toast.success('合成完成')
-    pendingComposeIds.value = pendingComposeIds.value.filter(item => item !== sb.id)
-    refresh()
+    delete failedComposeMessages.value[sbId]
+    if (!isPendingCompose(sbId)) pendingComposeIds.value.push(sbId)
+    await composeAPI.shot(sbId)
+    await refresh()
+    watchAsyncResult(() => {
+      const target = sbs.value.find(s => s.id === sbId)
+      const ok = !!(target?.composed_video_url || target?.composedVideoUrl)
+      const err = composeFailMessage(sbId)
+      if (ok) {
+        pendingComposeIds.value = pendingComposeIds.value.filter(item => item !== sbId)
+        return true
+      }
+      if (err) {
+        pendingComposeIds.value = pendingComposeIds.value.filter(item => item !== sbId)
+        return true
+      }
+      return false
+    }, 60, 3000, (finishedOk) => {
+      if (!finishedOk) {
+        toast.warning('合成未完成或超时，请刷新查看')
+        return
+      }
+      if (composeFailMessage(sbId)) return
+      const target = sbs.value.find(s => s.id === sbId)
+      if (target?.composed_video_url || target?.composedVideoUrl) toast.success('镜头合成成功生成')
+      else toast.warning('合成状态不明，请刷新查看')
+    })
   } catch (e) {
-    pendingComposeIds.value = pendingComposeIds.value.filter(item => item !== sb.id)
+    pendingComposeIds.value = pendingComposeIds.value.filter(item => item !== sbId)
     failedComposeMessages.value = {
       ...failedComposeMessages.value,
-      [sb.id]: e.message,
+      [sbId]: e.message,
     }
     toast.error(e.message)
   }
 }
 function batchVideos() {
   const pendingIds = sbs.value.filter(s => !hasVid(s)).map(s => s.id)
+  if (!pendingIds.length) {
+    toast.info('当前没有待生成的镜头视频')
+    return
+  }
+  batchVideosBusy.value = true
   pendingIds.forEach(id => {
     const sb = sbs.value.find(item => item.id === id)
     if (sb) genVid(sb)
   })
-  if (pendingIds.length) {
-    pendingVideoIds.value = [...new Set([...pendingVideoIds.value, ...pendingIds])]
-    watchAsyncResult(() => pendingIds.every(id => {
-      const target = sbs.value.find(s => s.id === id)
-      const done = !!(target?.video_url || target?.videoUrl)
-      if (done) pendingVideoIds.value = pendingVideoIds.value.filter(item => item !== id)
-      return done
-    }), 80, 4000)
-  }
+  pendingVideoIds.value = [...new Set([...pendingVideoIds.value, ...pendingIds])]
+  watchAsyncResult(() => pendingIds.every(id => {
+    const target = sbs.value.find(s => s.id === id)
+    const done = !!(target?.video_url || target?.videoUrl)
+    if (done) pendingVideoIds.value = pendingVideoIds.value.filter(item => item !== id)
+    return done
+  }), 80, 4000, (success) => {
+    batchVideosBusy.value = false
+    if (success) toast.success(`视频成功生成（${pendingIds.length} 条）`)
+    else toast.warning('部分视频可能仍在生成，请稍后刷新')
+  })
 }
 async function batchCompose() {
-  await composeAPI.all(epId.value)
-  pendingComposeIds.value = [...new Set(sbs.value.filter(sb => !!sb.video_url || !!sb.videoUrl).map(sb => sb.id))]
-  toast.success('批量合成已开始')
-  pollComposeStatus()
+  batchComposeBusy.value = true
+  try {
+    await composeAPI.all(epId.value)
+    pendingComposeIds.value = [...new Set(sbs.value.filter(sb => !!sb.video_url || !!sb.videoUrl).map(sb => sb.id))]
+    toast.info('批量合成已开始…')
+    pollComposeStatus()
+  } catch (e) {
+    batchComposeBusy.value = false
+    toast.error(e?.message || '批量合成请求失败')
+  }
 }
 async function doMerge() {
-  await mergeAPI.merge(epId.value); toast.success('拼接中...')
-  const poll = setInterval(async () => {
-    try { mergeData.value = await mergeAPI.status(epId.value) } catch {}
-    if (mergeData.value?.status === 'completed' || mergeData.value?.status === 'failed') {
-      clearInterval(poll)
-      mergeData.value.status === 'completed' ? toast.success('拼接完成') : toast.error('拼接失败')
-    }
-  }, 3000)
+  mergeMerging.value = true
+  try {
+    await mergeAPI.merge(epId.value)
+    const poll = setInterval(async () => {
+      try { mergeData.value = await mergeAPI.status(epId.value) } catch {}
+      if (mergeData.value?.status === 'completed' || mergeData.value?.status === 'failed') {
+        clearInterval(poll)
+        mergeMerging.value = false
+        mergeData.value.status === 'completed' ? toast.success('全集拼接成功生成') : toast.error('拼接失败')
+      }
+    }, 3000)
+  } catch (e) {
+    mergeMerging.value = false
+    toast.error(e?.message || '拼接请求失败')
+  }
 }
 
 async function clearMergeExport() {
@@ -3007,36 +3361,132 @@ async function clearMergeExport() {
 }
 
 async function pollComposeStatus() {
-  for (let i = 0; i < 120; i++) {
-    await sleep(3000)
-    try {
-      const res = await composeAPI.status(epId.value)
-      await refresh()
-      const items = Array.isArray(res?.items) ? res.items : []
-      const processingIds = items.filter(item => item.status === 'compose_processing').map(item => item.id)
-      pendingComposeIds.value = processingIds
+  try {
+    for (let i = 0; i < 120; i++) {
+      await sleep(3000)
+      try {
+        const res = await composeAPI.status(epId.value)
+        await refresh()
+        const items = Array.isArray(res?.items) ? res.items : []
+        const processingIds = items.filter(item => item.status === 'compose_processing').map(item => item.id)
+        pendingComposeIds.value = processingIds
 
-      const failedItems = items.filter(item => item.status === 'compose_failed')
-      if (failedItems.length) {
-        const next = { ...failedComposeMessages.value }
-        failedItems.forEach((item) => {
-          next[item.id] = item.error_msg || item.errorMsg || '视频合成失败'
-        })
-        failedComposeMessages.value = next
-      }
+        const failedItems = items.filter(item => item.status === 'compose_failed')
+        if (failedItems.length) {
+          const next = { ...failedComposeMessages.value }
+          failedItems.forEach((item) => {
+            next[item.id] = item.error_msg || item.errorMsg || '视频合成失败'
+          })
+          failedComposeMessages.value = next
+        }
 
-      if (!processingIds.length) {
-        if (failedItems.length) toast.error(`有 ${failedItems.length} 个镜头合成失败`)
-        else toast.success('批量合成完成')
-        return
-      }
-    } catch {}
+        if (!processingIds.length) {
+          if (failedItems.length) toast.error(`有 ${failedItems.length} 个镜头合成失败`)
+          else toast.success('批量合成成功生成')
+          return
+        }
+      } catch {}
+    }
+  } finally {
+    batchComposeBusy.value = false
   }
 }
 function getRefs(sb) {
   const raw = sb.reference_images || sb.referenceImages
   if (!raw) return []
   try { return JSON.parse(raw) } catch { return [] }
+}
+
+function getCharRefs(c) {
+  if (!c) return []
+  return getRefs(c)
+}
+
+function getSceneRefs(s) {
+  if (!s) return []
+  const raw = s.reference_images || s.referenceImages
+  if (!raw) return []
+  try { return JSON.parse(raw) } catch { return [] }
+}
+
+const MAX_USER_REFERENCE_IMAGES = 6
+
+async function persistStoryboardReferenceImages(sb, paths) {
+  const json = JSON.stringify(paths)
+  await storyboardAPI.update(sb.id, { reference_images: json })
+  sb.reference_images = json
+  sb.referenceImages = json
+}
+
+function openUserReferenceUpload(sb) {
+  if (!sb) return
+  if (getRefs(sb).length >= MAX_USER_REFERENCE_IMAGES) {
+    toast.warning(`参考图最多 ${MAX_USER_REFERENCE_IMAGES} 张`)
+    return
+  }
+  openLocalImageUpload({ kind: 'storyboard_reference', id: sb.id })
+}
+
+async function removeUserReferenceImage(sb, index) {
+  const list = getRefs(sb).filter((_, i) => i !== index)
+  try {
+    await persistStoryboardReferenceImages(sb, list)
+    toast.success('已移除参考图')
+  } catch (e) {
+    toast.error(e?.message || '移除失败')
+  }
+}
+
+async function persistCharReferenceImages(c, paths) {
+  const json = JSON.stringify(paths)
+  await characterAPI.update(c.id, { reference_images: json })
+  c.reference_images = json
+  c.referenceImages = json
+}
+
+function openCharReferenceUpload(c) {
+  if (!c) return
+  if (getCharRefs(c).length >= MAX_USER_REFERENCE_IMAGES) {
+    toast.warning(`参考图最多 ${MAX_USER_REFERENCE_IMAGES} 张`)
+    return
+  }
+  openLocalImageUpload({ kind: 'character_reference', id: c.id })
+}
+
+async function removeCharReferenceImage(c, index) {
+  const list = getCharRefs(c).filter((_, i) => i !== index)
+  try {
+    await persistCharReferenceImages(c, list)
+    toast.success('已移除参考图')
+  } catch (e) {
+    toast.error(e?.message || '移除失败')
+  }
+}
+
+async function persistSceneReferenceImages(s, paths) {
+  const json = JSON.stringify(paths)
+  await sceneAPI.update(s.id, { reference_images: json })
+  s.reference_images = json
+  s.referenceImages = json
+}
+
+function openSceneReferenceUpload(s) {
+  if (!s) return
+  if (getSceneRefs(s).length >= MAX_USER_REFERENCE_IMAGES) {
+    toast.warning(`参考图最多 ${MAX_USER_REFERENCE_IMAGES} 张`)
+    return
+  }
+  openLocalImageUpload({ kind: 'scene_reference', id: s.id })
+}
+
+async function removeSceneReferenceImage(s, index) {
+  const list = getSceneRefs(s).filter((_, i) => i !== index)
+  try {
+    await persistSceneReferenceImages(s, list)
+    toast.success('已移除参考图')
+  } catch (e) {
+    toast.error(e?.message || '移除失败')
+  }
 }
 
 async function loadConfigs() {
@@ -3233,6 +3683,7 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 .studio-actions {
   display: flex;
   gap: 6px;
+  align-items: center;
 }
 .studio-topbar .btn {
   height: 28px;
@@ -3748,6 +4199,74 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 /* Field */
 .field { display: flex; flex-direction: column; gap: 5px; }
 .field-label { font-size: 12px; font-weight: 500; color: var(--text-1); }
+.user-ref-field { margin-top: 4px; }
+.user-ref-hint {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-3);
+}
+.user-ref-thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+.user-ref-thumbs--compact { margin-top: 4px; }
+.prompt-gear-user-refs { margin-top: 4px; }
+.user-ref-thumb {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  flex-shrink: 0;
+}
+.user-ref-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  cursor: zoom-in;
+}
+.user-ref-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.user-ref-remove:hover { background: var(--error); }
+.user-ref-add {
+  width: 72px;
+  height: 72px;
+  border-radius: var(--radius);
+  border: 1px dashed var(--border);
+  background: var(--bg-2);
+  color: var(--text-2);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.user-ref-add:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-bg);
+}
+.user-ref-add:disabled { opacity: 0.45; cursor: not-allowed; }
 .field-row { display: flex; gap: 12px; }
 .field-grid { display: grid; gap: 12px; }
 .field-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -3849,6 +4368,19 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 }
 .asset-cover-empty { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; color: var(--text-3); }
 .asset-body { padding: 8px 10px; }
+.asset-refs--card {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 10px;
+  border-top: 1px solid var(--border);
+}
+.asset-refs-label {
+  flex-shrink: 0;
+  font-size: 10px;
+  line-height: 1.5;
+  padding-top: 4px;
+}
 .asset-name { font-size: 13px; font-weight: 600; }
 .asset-meta { font-size: 11px; }
 .asset-foot { display: flex; align-items: center; gap: 4px; padding: 6px 10px; border-top: 1px solid var(--border); }
@@ -3890,12 +4422,29 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 }
 .frame-thumb-upload:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
 .frame-thumb-upload:disabled { opacity: 0.4; cursor: not-allowed; }
-.frame-composed-upload { margin-top: 6px; padding-left: 2px; }
+.frame-composed-upload { flex-basis: 100%; margin-top: 4px; padding-left: 2px; }
+
+.frame-refs-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  flex-basis: 100%;
+  width: 100%;
+  padding: 6px 0 0;
+  margin-top: 4px;
+  border-top: 1px solid var(--border);
+}
+.frame-refs-label {
+  flex-shrink: 0;
+  font-size: 10px;
+  line-height: 1.5;
+  padding-top: 4px;
+}
 
 /* Frame grid */
 .frame-grid { display: flex; flex-direction: column; gap: 8px; }
 .frame-row {
-  display: flex; align-items: center; gap: 14px;
+  display: flex; flex-wrap: wrap; align-items: flex-start; gap: 14px;
   padding: 12px 14px; cursor: pointer;
   border-radius: var(--radius-lg);
   transition: all 0.15s;
@@ -4037,6 +4586,142 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
   background: rgba(255,255,255,0.9);
 }
 
+/* 顶栏齿轮：提示词面板 */
+.prompt-gear-overlay {
+  z-index: 200;
+  padding: 24px;
+}
+.prompt-gear-dialog {
+  width: min(720px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 18px 14px;
+  overflow: hidden;
+  background: var(--bg-0);
+  border: 1px solid var(--border);
+}
+.prompt-gear-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.prompt-gear-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  font-family: var(--font-display);
+  color: var(--text-0);
+}
+.prompt-gear-sub {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-3);
+}
+.prompt-gear-tabs {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.prompt-gear-tab {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text-2);
+  cursor: pointer;
+}
+.prompt-gear-tab.active {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--accent-text);
+}
+.prompt-gear-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+}
+.prompt-gear-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.prompt-gear-textarea {
+  min-height: 100px;
+  resize: vertical;
+  font-size: 13px;
+  line-height: 1.55;
+}
+.prompt-gear-save { align-self: flex-start; margin-top: 2px; }
+.card-prompt-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 4px;
+}
+.prompt-gear-empty {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-3);
+  padding: 12px 0;
+}
+.prompt-gear-details {
+  font-size: 12px;
+  color: var(--text-2);
+}
+.prompt-gear-details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text-1);
+}
+.prompt-gear-pre {
+  margin: 8px 0 0;
+  padding: 10px 12px;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  max-height: 160px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  color: var(--text-1);
+}
+.prompt-gear-cell-hint {
+  margin: 4px 0 0;
+  font-size: 11px;
+  color: var(--text-3);
+}
+.prompt-gear-cell-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 11px;
+  color: var(--text-2);
+  line-height: 1.5;
+}
+.prompt-gear-cell-item {
+  margin-bottom: 4px;
+}
+.prompt-gear-cell-idx {
+  font-weight: 700;
+  color: var(--text-3);
+  margin-right: 6px;
+}
+
 /* Grid tool dialog */
 .grid-tool { width: min(1320px, calc(100vw - 40px)); max-height: calc(100vh - 48px); display: flex; flex-direction: column; overflow: hidden; animation: scaleIn 0.2s var(--ease-out); }
 .grid-tool-head { display: flex; align-items: center; gap: 8px; padding: 16px 20px; border-bottom: 1px solid var(--border); flex-shrink: 0; }
@@ -4108,7 +4793,12 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 /* Prompt preview */
 .grid-prompt-summary { background: var(--bg-2); border: 1px solid var(--border); border-radius: var(--radius); padding: 12px 14px; }
 .grid-prompt-label { display: flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 600; color: var(--text-2); margin-bottom: 6px; }
-.grid-prompt-text { font-size: 12px; color: var(--text-1); line-height: 1.7; }
+.grid-prompt-edit {
+  width: 100%;
+  margin-top: 6px;
+  font-size: 12px;
+  min-height: 140px;
+}
 
 .grid-blank-preview {
   display: grid;

--- a/frontend/app/pages/settings.vue
+++ b/frontend/app/pages/settings.vue
@@ -117,6 +117,27 @@
         </div>
       </div>
 
+      <!-- ===== 工作台流水线 ===== -->
+      <div v-else-if="tab === 'workflow'" class="settings-scroll">
+        <div class="settings-head">
+          <h2 class="settings-title">工作台流水线</h2>
+          <p class="settings-desc">可按习惯省略「视频合成」环节：镜头视频生成完成后可直接进入「拼接导出」。</p>
+        </div>
+        <section class="card setup-panel workflow-pref-card">
+          <div class="workflow-pref-row">
+            <div>
+              <div class="setup-title">跳过「视频合成」步骤</div>
+              <div class="setup-desc workflow-pref-desc">开启后侧边栏与制作顶栏不再显示该步，总进度按 10 步计。拼接仍优先使用已合成成片，否则使用已生成视频。</div>
+            </div>
+            <label class="toggle">
+              <input type="checkbox" :checked="skipVideoCompose" @change="setSkipVideoCompose($event.target.checked)">
+              <span />
+            </label>
+          </div>
+          <p class="setup-desc workflow-env-hint">构建前端时可设环境变量 <code class="mono">NUXT_PUBLIC_SKIP_VIDEO_COMPOSE=true</code> 作为默认；一旦在浏览器里切换过本开关，以本地保存为准。</p>
+        </section>
+      </div>
+
       <!-- ===== Agent 配置 ===== -->
       <div v-else-if="tab === 'agents'" class="settings-scroll">
         <div class="settings-head">
@@ -391,7 +412,7 @@
 </template>
 
 <script setup>
-import { Plus, Pencil, Trash2, FileText, ChevronDown, Check, Loader2, Bot, Cpu, Sparkles } from 'lucide-vue-next'
+import { Plus, Pencil, Trash2, FileText, ChevronDown, Check, Loader2, Bot, Cpu, Sparkles, Clapperboard } from 'lucide-vue-next'
 import BaseSelect from '~/components/BaseSelect.vue'
 import { toast } from 'vue-sonner'
 import { aiConfigAPI, agentConfigAPI, skillsAPI } from '~/composables/useApi'
@@ -400,8 +421,10 @@ import brandLogo from '~/assets/huobao-logo.png'
 const showBrandImage = ref(true)
 const tab = ref('ai')
 const showAdvanced = ref(false)
+const { skipVideoCompose, setSkipVideoCompose } = usePipelinePrefs()
 const baseTabs = [
   { id: 'ai', label: 'AI 服务', icon: Cpu },
+  { id: 'workflow', label: '工作台', icon: Clapperboard },
 ]
 const advancedTabs = [
   { id: 'agents', label: 'Agent 配置', icon: Bot },
@@ -1044,6 +1067,12 @@ onMounted(() => { loadCfgs(); loadAgents(); loadAllSkills() })
 .toggle span::before { content: ''; position: absolute; width: 13px; height: 13px; left: 2px; bottom: 2px; background: var(--bg-0); border-radius: 50%; transition: 0.2s; box-shadow: var(--shadow); }
 .toggle input:checked + span { background: var(--accent); }
 .toggle input:checked + span::before { transform: translateX(13px); }
+
+.workflow-pref-card { padding: 18px 16px; }
+.workflow-pref-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.workflow-pref-desc { margin-top: 6px; max-width: 560px; }
+.workflow-env-hint { margin-top: 14px; margin-bottom: 0; font-size: 11px; color: var(--text-3); }
+.workflow-env-hint .mono { font-family: var(--font-mono, monospace); font-size: 11px; background: var(--bg-2); padding: 2px 6px; border-radius: 4px; }
 
 /* Agent */
 .agent-list { display: flex; flex-direction: column; gap: 8px; }

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,6 +1,14 @@
 export default defineNuxtConfig({
   srcDir: 'app/',
   ssr: false,
+  runtimeConfig: {
+    public: {
+      /** 为 true 时隐藏「视频合成」步骤，视频生成完成后可直接去拼接导出（本地设置可覆盖） */
+      skipVideoCompose:
+        process.env.NUXT_PUBLIC_SKIP_VIDEO_COMPOSE === '1'
+        || process.env.NUXT_PUBLIC_SKIP_VIDEO_COMPOSE === 'true',
+    },
+  },
   devtools: { enabled: false },
   experimental: {
     appManifest: false,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1407,7 +1406,6 @@
       "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.2.tgz",
       "integrity": "sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "c12": "^3.3.3",
         "consola": "^3.4.2",
@@ -3659,7 +3657,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.31.tgz",
       "integrity": "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.2",
         "@vue/compiler-core": "3.5.31",
@@ -3819,7 +3816,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4138,7 +4134,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4324,7 +4319,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4462,7 +4456,6 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4527,8 +4520,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
       "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clipboardy": {
       "version": "4.0.0",
@@ -6886,7 +6878,6 @@
       "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.21.2.tgz",
       "integrity": "sha512-XzZFj2KMK16zE0TfrGpjvgc378wZWvDzIpunHOHOT0Jj8zbV5qT1uQKaJb+fAHv6lf1A4nOMMWHrTmjAK4u0Zg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dxup/nuxt": "^0.4.0",
         "@nuxt/cli": "^3.34.0",
@@ -7124,7 +7115,6 @@
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.117.0.tgz",
       "integrity": "sha512-l3cbgK5wUvWDVNWM/JFU77qDdGZK1wudnLsFcrRyNo/bL1CyU8pC25vDhMHikVY29lbK2InTWsX42RxVSutUdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.117.0"
       },
@@ -7324,7 +7314,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8003,7 +7992,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8861,7 +8849,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9297,7 +9284,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9662,7 +9648,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.31.tgz",
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/compiler-sfc": "3.5.31",
@@ -9699,7 +9684,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -9901,7 +9885,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
- 后端新增 timeline 路由：音轨提取、成片渲染，以及 NDJSON 流式进度（render-stream）。

- timeline-edit 按 ffmpeg 阶段异步推进并上报百分比；抽取 ffmpeg-bin、merge-cleanup 等。

- 调整 ffmpeg-compose / ffmpeg-merge；grid、merge、scenes、storyboards 等路由配合流水线。

- 前端本集页改为 episode/[n]/index.vue，新增简易剪辑 edit.vue（时间线、导出进度）。

- useApi 扩展 timelineAPI；default 布局主区域支持纵向滚动；usePipelinePrefs、settings、nuxt 代理与示例配置。

Made-with: Cursor