### PR TITLE
Private/fix 90 local image upload

### DIFF
--- a/backend/src/agents/tools/storyboard-tools.ts
+++ b/backend/src/agents/tools/storyboard-tools.ts
@@ -55,6 +55,35 @@ function validateStoryboardBindings(episodeId: number, sceneId: number | null | 
   }
 }
 
+function toOptionalNumber(value: unknown): number | null {
+  if (value == null || value === '') return null
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'string') {
+    const parsed = Number(value.trim())
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function toNumberArray(value: unknown): number[] {
+  if (!Array.isArray(value)) return []
+  return [...new Set(value
+    .map(item => toOptionalNumber(item))
+    .filter((item): item is number => item != null))]
+}
+
+function sanitizeStoryboardBindings(episodeId: number, sceneId: unknown, characterIds: unknown) {
+  const episodeSceneIds = getEpisodeSceneIds(episodeId)
+  const episodeCharacterIds = getEpisodeCharacterIds(episodeId)
+  const resolvedSceneId = toOptionalNumber(sceneId)
+  const resolvedCharacterIds = toNumberArray(characterIds)
+
+  return {
+    sceneId: resolvedSceneId != null && episodeSceneIds.has(resolvedSceneId) ? resolvedSceneId : null,
+    characterIds: resolvedCharacterIds.filter(id => episodeCharacterIds.has(id)),
+  }
+}
+
 export function createStoryboardTools(episodeId: number, dramaId: number) {
   const readStoryboardContext = createTool({
     id: 'read_storyboard_context',
@@ -150,7 +179,7 @@ export function createStoryboardTools(episodeId: number, dramaId: number) {
     description: 'Save generated storyboards. Replaces all existing storyboards for this episode.',
     inputSchema: z.object({
       storyboards: z.array(z.object({
-        shot_number: z.number(),
+        shot_number: z.coerce.number(),
         title: z.string().optional(),
         shot_type: z.string().optional(),
         angle: z.string().optional(),
@@ -166,18 +195,18 @@ export function createStoryboardTools(episodeId: number, dramaId: number) {
         video_prompt: z.string().optional(),
         bgm_prompt: z.string().optional(),
         sound_effect: z.string().optional(),
-        duration: z.number().optional(),
-        scene_id: z.number().nullable().optional(),
-        character_ids: z.array(z.number()).optional(),
+        duration: z.coerce.number().optional(),
+        scene_id: z.union([z.number(), z.string(), z.null()]).optional(),
+        character_ids: z.array(z.union([z.number(), z.string()])).optional(),
       })),
     }),
-    execute: async ({ storyboards }) => {
+    execute: async ({ storyboards }: any) => {
       const ts = now()
       logTaskProgress('StoryboardTool', 'save-begin', {
         episodeId,
         dramaId,
         count: storyboards.length,
-        shotNumbers: storyboards.map(sb => sb.shot_number).join(','),
+        shotNumbers: storyboards.map((sb: any) => sb.shot_number).join(','),
       })
       const existingStoryboardIds = db.select().from(schema.storyboards)
         .where(eq(schema.storyboards.episodeId, episodeId)).all()
@@ -191,7 +220,9 @@ export function createStoryboardTools(episodeId: number, dramaId: number) {
 
       let totalDuration = 0
       for (const sb of storyboards) {
-        validateStoryboardBindings(episodeId, sb.scene_id, sb.character_ids)
+        const { sceneId, characterIds } = sanitizeStoryboardBindings(episodeId, sb.scene_id, sb.character_ids)
+        validateStoryboardBindings(episodeId, sceneId, characterIds)
+        const duration = typeof sb.duration === 'number' && Number.isFinite(sb.duration) ? sb.duration : 10
         const res = db.insert(schema.storyboards).values({
           episodeId,
           storyboardNumber: sb.shot_number,
@@ -203,11 +234,11 @@ export function createStoryboardTools(episodeId: number, dramaId: number) {
           atmosphere: sb.atmosphere, imagePrompt: sb.image_prompt,
           videoPrompt: sb.video_prompt, bgmPrompt: sb.bgm_prompt,
           soundEffect: sb.sound_effect,
-          sceneId: sb.scene_id, duration: sb.duration || 10,
+          sceneId, duration,
           createdAt: ts, updatedAt: ts,
         }).run()
-        syncStoryboardCharacters(Number(res.lastInsertRowid), sb.character_ids || [])
-        totalDuration += sb.duration || 10
+        syncStoryboardCharacters(Number(res.lastInsertRowid), characterIds)
+        totalDuration += duration
       }
 
       db.update(schema.episodes)
@@ -243,9 +274,9 @@ export function createStoryboardTools(episodeId: number, dramaId: number) {
       sound_effect: z.string().optional(),
       description: z.string().optional(),
       dialogue: z.string().optional(),
-      scene_id: z.number().nullable().optional(),
-      character_ids: z.array(z.number()).optional(),
-      duration: z.number().optional(),
+      scene_id: z.union([z.number(), z.string(), z.null()]).optional(),
+      character_ids: z.array(z.union([z.number(), z.string()])).optional(),
+      duration: z.coerce.number().optional(),
     }),
     execute: async ({ storyboard_id, ...fields }) => {
       const [storyboard] = db.select().from(schema.storyboards).where(eq(schema.storyboards.id, storyboard_id)).all()
@@ -256,14 +287,21 @@ export function createStoryboardTools(episodeId: number, dramaId: number) {
         fields: Object.keys(fields),
       })
 
+      const hasSceneField = Object.prototype.hasOwnProperty.call(fields, 'scene_id')
+      const hasCharacterField = Object.prototype.hasOwnProperty.call(fields, 'character_ids')
+      const fallbackCharacterIds = db.select().from(schema.storyboardCharacters)
+        .where(eq(schema.storyboardCharacters.storyboardId, storyboard_id)).all()
+        .map(link => link.characterId)
+      const sanitizedBindings = sanitizeStoryboardBindings(
+        episodeId,
+        hasSceneField ? fields.scene_id : storyboard.sceneId,
+        hasCharacterField ? fields.character_ids : fallbackCharacterIds,
+      )
+
       validateStoryboardBindings(
         episodeId,
-        'scene_id' in fields ? fields.scene_id : storyboard.sceneId,
-        'character_ids' in fields
-          ? fields.character_ids
-          : db.select().from(schema.storyboardCharacters)
-              .where(eq(schema.storyboardCharacters.storyboardId, storyboard_id)).all()
-              .map(link => link.characterId),
+        sanitizedBindings.sceneId,
+        sanitizedBindings.characterIds,
       )
 
       const updates: Record<string, any> = { updatedAt: now() }
@@ -282,10 +320,10 @@ export function createStoryboardTools(episodeId: number, dramaId: number) {
       if ('sound_effect' in fields) updates.soundEffect = fields.sound_effect
       if ('description' in fields) updates.description = fields.description
       if ('dialogue' in fields) updates.dialogue = fields.dialogue
-      if ('scene_id' in fields) updates.sceneId = fields.scene_id
+      if (hasSceneField) updates.sceneId = sanitizedBindings.sceneId
       if ('duration' in fields) updates.duration = fields.duration
       db.update(schema.storyboards).set(updates).where(eq(schema.storyboards.id, storyboard_id)).run()
-      if ('character_ids' in fields) syncStoryboardCharacters(storyboard_id, fields.character_ids || [])
+      if (hasCharacterField) syncStoryboardCharacters(storyboard_id, sanitizedBindings.characterIds)
       logTaskSuccess('StoryboardTool', 'update-complete', {
         episodeId,
         storyboardId: storyboard_id,

--- a/backend/src/routes/scenes.ts
+++ b/backend/src/routes/scenes.ts
@@ -33,6 +33,8 @@ app.put('/:id', async (c) => {
   if (body.location !== undefined) updates.location = body.location
   if (body.time !== undefined) updates.time = body.time
   if (body.prompt !== undefined) updates.prompt = body.prompt
+  if (body.image_url !== undefined) updates.imageUrl = body.image_url
+  if (body.local_path !== undefined) updates.localPath = body.local_path
   db.update(schema.scenes).set(updates).where(eq(schema.scenes.id, id)).run()
   return success(c)
 })

--- a/backend/src/routes/storyboards.ts
+++ b/backend/src/routes/storyboards.ts
@@ -123,6 +123,8 @@ app.put('/:id', async (c) => {
     image_prompt: 'imagePrompt', scene_id: 'sceneId', location: 'location',
     time: 'time', atmosphere: 'atmosphere', result: 'result',
     bgm_prompt: 'bgmPrompt', sound_effect: 'soundEffect',
+    first_frame_image: 'firstFrameImage', last_frame_image: 'lastFrameImage',
+    composed_image: 'composedImage', reference_images: 'referenceImages',
   }
 
   const updates: Record<string, any> = { updatedAt: now() }

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -35,6 +35,22 @@ export const api = {
   del: <T = any>(p: string) => req<T>('DELETE', p),
 }
 
+export const uploadAPI = {
+  image: async (file: File) => {
+    const form = new FormData()
+    form.append('file', file)
+    const resp = await fetch(`${BASE}/upload/image`, {
+      method: 'POST',
+      body: form,
+    })
+    const json = await resp.json()
+    if (!resp.ok || (json.code && json.code >= 400)) {
+      throw new Error(json.message || `${resp.status}`)
+    }
+    return json.data ?? json
+  },
+}
+
 export const dramaAPI = {
   list: () => api.get<{ items: any[] }>('/dramas'),
   get: (id: number) => api.get(`/dramas/${id}`),

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -28,6 +28,33 @@ async function req<T = any>(method: string, path: string, body?: any): Promise<T
   }
 }
 
+async function reqForm<T = any>(method: string, path: string, formData: FormData): Promise<T> {
+  const opts: RequestInit = { method, body: formData }
+
+  const start = performance.now()
+  console.log(`%c[API] %c${method} %c${path}`, 'color:#888', 'color:#4fc3f7;font-weight:bold', 'color:#ccc', '[form-data]')
+
+  try {
+    const resp = await fetch(`${BASE}${path}`, opts)
+    const json = await resp.json()
+    const ms = Math.round(performance.now() - start)
+
+    if (!resp.ok || (json.code && json.code >= 400)) {
+      console.log(`%c[API] %c${method} ${path} %c${resp.status} %c${ms}ms`, 'color:#888', 'color:#ef5350', 'color:#ef5350;font-weight:bold', 'color:#888', json.message || '')
+      throw new Error(json.message || `${resp.status}`)
+    }
+
+    console.log(`%c[API] %c${method} ${path} %c${resp.status} %c${ms}ms`, 'color:#888', 'color:#66bb6a', 'color:#66bb6a;font-weight:bold', 'color:#888')
+    return json.data ?? json
+  } catch (err: any) {
+    if (!err.message?.match(/^\d{3}$/)) {
+      const ms = Math.round(performance.now() - start)
+      console.log(`%c[API] %c${method} ${path} %cERROR %c${ms}ms`, 'color:#888', 'color:#ef5350', 'color:#ef5350;font-weight:bold', 'color:#888', err.message)
+    }
+    throw err
+  }
+}
+
 export const api = {
   get: <T = any>(p: string) => req<T>('GET', p),
   post: <T = any>(p: string, b?: any) => req<T>('POST', p, b),
@@ -35,21 +62,6 @@ export const api = {
   del: <T = any>(p: string) => req<T>('DELETE', p),
 }
 
-export const uploadAPI = {
-  image: async (file: File) => {
-    const form = new FormData()
-    form.append('file', file)
-    const resp = await fetch(`${BASE}/upload/image`, {
-      method: 'POST',
-      body: form,
-    })
-    const json = await resp.json()
-    if (!resp.ok || (json.code && json.code >= 400)) {
-      throw new Error(json.message || `${resp.status}`)
-    }
-    return json.data ?? json
-  },
-}
 
 export const dramaAPI = {
   list: () => api.get<{ items: any[] }>('/dramas'),
@@ -83,6 +95,7 @@ export const characterAPI = {
 }
 
 export const sceneAPI = {
+  update: (id: number, data: any) => api.put(`/scenes/${id}`, data),
   generateImage: (id: number, episodeId: number) => api.post(`/scenes/${id}/generate-image`, { episode_id: episodeId }),
 }
 
@@ -142,4 +155,12 @@ export const skillsAPI = {
 export const voicesAPI = {
   list: (provider?: string) => api.get(`/ai-voices${provider ? `?provider=${provider}` : ''}`),
   sync: () => api.post('/ai-voices/sync', {}),
+}
+
+export const uploadAPI = {
+  image: (file: File) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    return reqForm('POST', '/upload/image', formData)
+  },
 }

--- a/frontend/app/pages/drama/[id]/episode/[episodeNumber].vue
+++ b/frontend/app/pages/drama/[id]/episode/[episodeNumber].vue
@@ -771,6 +771,14 @@
                 <div class="asset-foot">
                   <span :class="['dot', (c.image_url || c.imageUrl) && 'ok', isPendingCharImage(c.id) && 'pending']" />
                   <span class="dim" style="font-size:10px">{{ (c.image_url || c.imageUrl) ? '已生成' : (isPendingCharImage(c.id) ? '生成中' : '待生成') }}</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    class="hidden-file-input"
+                    :ref="(el) => setCharUploadInput(c.id, el)"
+                    @change="uploadCharLocalImage(c, $event)"
+                  />
+                  <button class="btn btn-sm" @click="openCharUpload(c.id)">上传本地</button>
                   <button class="btn btn-sm ml-auto" :disabled="isPendingCharImage(c.id)" @click="genCharImg(c.id)">{{ isPendingCharImage(c.id) ? '生成中' : '生成' }}</button>
                 </div>
               </div>
@@ -976,6 +984,14 @@
                         </span>
                       </div>
                       <span class="frame-thumb-label">{{ isPendingShotFrame(sb.id, 'first_frame') ? '首帧生成中' : '首帧' }}</span>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        class="hidden-file-input"
+                        :ref="(el) => setShotFrameUploadInput(sb.id, 'first_frame', el)"
+                        @change="uploadShotFrameLocalImage(sb, 'first_frame', $event)"
+                      />
+                      <button class="btn btn-sm frame-upload-btn" @click.stop="openShotFrameUpload(sb.id, 'first_frame')">上传本地</button>
                     </div>
                     <div v-if="frameMode === 'first_last'" class="frame-thumb-wrap">
                       <div class="frame-thumb" @click.stop="!isPendingShotFrame(sb.id, 'last_frame') && genShotFrame(sb, 'last_frame')">
@@ -994,6 +1010,14 @@
                         </span>
                       </div>
                       <span class="frame-thumb-label">{{ isPendingShotFrame(sb.id, 'last_frame') ? '尾帧生成中' : '尾帧' }}</span>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        class="hidden-file-input"
+                        :ref="(el) => setShotFrameUploadInput(sb.id, 'last_frame', el)"
+                        @change="uploadShotFrameLocalImage(sb, 'last_frame', $event)"
+                      />
+                      <button class="btn btn-sm frame-upload-btn" @click.stop="openShotFrameUpload(sb.id, 'last_frame')">上传本地</button>
                     </div>
                   </div>
                 </div>
@@ -1440,7 +1464,7 @@ import { toast } from 'vue-sonner'
 import {
   Users, MapPin, Video, ImageIcon, Layers, Mic2, FileText, FolderKanban, Clapperboard, Download,
 } from 'lucide-vue-next'
-import { dramaAPI, episodeAPI, storyboardAPI, characterAPI, sceneAPI, imageAPI, videoAPI, composeAPI, mergeAPI, gridAPI, aiConfigAPI, voicesAPI } from '~/composables/useApi'
+import { dramaAPI, episodeAPI, storyboardAPI, characterAPI, sceneAPI, imageAPI, videoAPI, composeAPI, mergeAPI, gridAPI, aiConfigAPI, voicesAPI, uploadAPI } from '~/composables/useApi'
 import { useAgent } from '~/composables/useAgent'
 import BaseSelect from '~/components/BaseSelect.vue'
 
@@ -1506,6 +1530,8 @@ const pendingComposeIds = ref([])
 const failedVideoMessages = ref({})
 const failedComposeMessages = ref({})
 const imageViewer = ref({ open: false, src: '', title: '' })
+const charUploadInputRefs = ref({})
+const shotFrameUploadInputRefs = ref({})
 
 function configLabel(config) {
   if (!config) return '未配置'
@@ -1545,6 +1571,83 @@ function isPendingSceneImage(id) {
 
 function framePendingKey(id, frameType) {
   return `${id}:${frameType}`
+}
+
+function setCharUploadInput(id, el) {
+  if (el) charUploadInputRefs.value[id] = el
+  else delete charUploadInputRefs.value[id]
+}
+
+function openCharUpload(id) {
+  const input = charUploadInputRefs.value[id]
+  if (input) input.click()
+}
+
+function shotFrameUploadKey(id, frameType) {
+  return `${id}:${frameType}`
+}
+
+function setShotFrameUploadInput(id, frameType, el) {
+  const key = shotFrameUploadKey(id, frameType)
+  if (el) shotFrameUploadInputRefs.value[key] = el
+  else delete shotFrameUploadInputRefs.value[key]
+}
+
+function openShotFrameUpload(id, frameType) {
+  const input = shotFrameUploadInputRefs.value[shotFrameUploadKey(id, frameType)]
+  if (input) input.click()
+}
+
+function getUploadPath(payload) {
+  return payload?.path || payload?.local_path || payload?.localPath || ''
+}
+
+async function uploadCharLocalImage(char, event) {
+  const file = event?.target?.files?.[0]
+  if (!file) return
+  event.target.value = ''
+  if (!String(file.type || '').startsWith('image/')) {
+    toast.error('请上传图片文件')
+    return
+  }
+  try {
+    const result = await uploadAPI.image(file)
+    const localPath = getUploadPath(result)
+    if (!localPath) throw new Error('上传结果缺少文件路径')
+    await characterAPI.update(char.id, { image_url: localPath, local_path: localPath })
+    char.image_url = localPath
+    char.imageUrl = localPath
+    char.local_path = localPath
+    char.localPath = localPath
+    toast.success('本地角色图已上传并替换')
+    await refresh()
+  } catch (e) {
+    toast.error(e.message || '上传失败')
+  }
+}
+
+async function uploadShotFrameLocalImage(sb, frameType, event) {
+  const file = event?.target?.files?.[0]
+  if (!file) return
+  event.target.value = ''
+  if (!String(file.type || '').startsWith('image/')) {
+    toast.error('请上传图片文件')
+    return
+  }
+  const field = frameType === 'last_frame' ? 'last_frame_image' : 'first_frame_image'
+  try {
+    const result = await uploadAPI.image(file)
+    const localPath = getUploadPath(result)
+    if (!localPath) throw new Error('上传结果缺少文件路径')
+    await storyboardAPI.update(sb.id, { [field]: localPath })
+    sb[field] = localPath
+    const camelField = toCamel(field)
+    if (camelField !== field) sb[camelField] = localPath
+    toast.success(frameType === 'last_frame' ? '尾帧已上传并替换' : '首帧已上传并替换')
+    await refresh()
+  } catch (e) {
+    toast.error(e.message || '上传失败')
+  }
 }
 
 function isPendingShotFrame(id, frameType) {
@@ -3695,6 +3798,7 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
 .frame-thumbs { display: flex; gap: 8px; flex-shrink: 0; }
 .frame-thumb-wrap { display: flex; flex-direction: column; gap: 3px; align-items: center; }
 .frame-thumb-label { font-size: 10px; font-weight: 600; color: var(--text-3); }
+.frame-upload-btn { height: 24px; padding: 0 8px; font-size: 10px; }
 .frame-thumb {
   position: relative; width: 130px; aspect-ratio: 16/9;
   border-radius: 6px; overflow: hidden;
@@ -3717,6 +3821,7 @@ onMounted(() => { refresh(); loadConfigs(); loadVoices() })
   background: var(--accent-dark);
   box-shadow: 0 0 0 3px rgba(76, 125, 255, 0.14);
 }
+.hidden-file-input { display: none; }
 
 /* Prod grid */
 .prod-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 12px; }

--- a/frontend/app/pages/drama/[id]/episode/[episodeNumber].vue
+++ b/frontend/app/pages/drama/[id]/episode/[episodeNumber].vue
@@ -778,7 +778,7 @@
                     :ref="(el) => setCharUploadInput(c.id, el)"
                     @change="uploadCharLocalImage(c, $event)"
                   />
-                  <button class="btn btn-sm" @click="openCharUpload(c.id)">上传本地</button>
+                  <button class="btn btn-sm" @click.stop="openCharUpload(c.id)">上传本地</button>
                   <button class="btn btn-sm ml-auto" :disabled="isPendingCharImage(c.id)" @click="genCharImg(c.id)">{{ isPendingCharImage(c.id) ? '生成中' : '生成' }}</button>
                 </div>
               </div>
@@ -818,6 +818,14 @@
                 <div class="asset-foot">
                   <span :class="['dot', (s.image_url || s.imageUrl) && 'ok', isPendingSceneImage(s.id) && 'pending']" />
                   <span class="dim" style="font-size:10px">{{ (s.image_url || s.imageUrl) ? '已生成' : (isPendingSceneImage(s.id) ? '生成中' : '待生成') }}</span>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    class="hidden-file-input"
+                    :ref="(el) => setSceneUploadInput(s.id, el)"
+                    @change="uploadSceneLocalImage(s, $event)"
+                  />
+                  <button class="btn btn-sm" @click.stop="openSceneUpload(s.id)">上传本地</button>
                   <button class="btn btn-sm ml-auto" :disabled="isPendingSceneImage(s.id)" @click="genSceneImg(s.id)">{{ isPendingSceneImage(s.id) ? '生成中' : '生成' }}</button>
                 </div>
               </div>
@@ -1532,6 +1540,7 @@ const failedComposeMessages = ref({})
 const imageViewer = ref({ open: false, src: '', title: '' })
 const charUploadInputRefs = ref({})
 const shotFrameUploadInputRefs = ref({})
+const sceneUploadInputRefs = ref({})
 
 function configLabel(config) {
   if (!config) return '未配置'
@@ -1598,6 +1607,16 @@ function openShotFrameUpload(id, frameType) {
   if (input) input.click()
 }
 
+function setSceneUploadInput(id, el) {
+  if (el) sceneUploadInputRefs.value[id] = el
+  else delete sceneUploadInputRefs.value[id]
+}
+
+function openSceneUpload(id) {
+  const input = sceneUploadInputRefs.value[id]
+  if (input) input.click()
+}
+
 function getUploadPath(payload) {
   return payload?.path || payload?.local_path || payload?.localPath || ''
 }
@@ -1644,6 +1663,30 @@ async function uploadShotFrameLocalImage(sb, frameType, event) {
     const camelField = toCamel(field)
     if (camelField !== field) sb[camelField] = localPath
     toast.success(frameType === 'last_frame' ? '尾帧已上传并替换' : '首帧已上传并替换')
+    await refresh()
+  } catch (e) {
+    toast.error(e.message || '上传失败')
+  }
+}
+
+async function uploadSceneLocalImage(scene, event) {
+  const file = event?.target?.files?.[0]
+  if (!file) return
+  event.target.value = ''
+  if (!String(file.type || '').startsWith('image/')) {
+    toast.error('请上传图片文件')
+    return
+  }
+  try {
+    const result = await uploadAPI.image(file)
+    const localPath = getUploadPath(result)
+    if (!localPath) throw new Error('上传结果缺少文件路径')
+    await sceneAPI.update(scene.id, { image_url: localPath, local_path: localPath })
+    scene.image_url = localPath
+    scene.imageUrl = localPath
+    scene.local_path = localPath
+    scene.localPath = localPath
+    toast.success('本地场景图已上传并替换')
     await refresh()
   } catch (e) {
     toast.error(e.message || '上传失败')


### PR DESCRIPTION
## 摘要
- 问题：当 AI 生成的分镜图或人物图不满意时，工作台缺少“上传本地图片替换”的入口，只能反复重生图。
- 影响：会增加生产时间与成本，且难以快速落地已有素材或手工修图结果。
- 方案：在工作台新增本地上传能力，支持替换角色图与分镜首/尾帧，并打通前后端存储与字段更新链路。

## 关联 Issue
- Closes #90

## 变更内容
### 1) 前端：新增本地上传 API
- 文件：`frontend/app/composables/useApi.ts`
- 新增 `uploadAPI.image(file)`，通过 `multipart/form-data` 调用 `/api/v1/upload/image`，统一返回上传结果并处理错误。

### 2) 前端：工作台支持上传并替换图片
- 文件：`frontend/app/pages/drama/[id]/episode/[episodeNumber].vue`
- 角色形象页（`prodTab === 'chars'`）：
  - 每个角色卡片新增“上传本地”按钮与隐藏文件输入。
  - 上传后调用 `characterAPI.update` 更新 `image_url/local_path`，即时替换显示并刷新数据。
- 镜头图片页（`prodTab === 'shots'`）：
  - 首帧、尾帧区域分别新增“上传本地”按钮与隐藏文件输入。
  - 上传后调用 `storyboardAPI.update` 更新 `first_frame_image` / `last_frame_image`，即时替换显示并刷新数据。
- 新增交互辅助逻辑：
  - 文件输入 ref 管理、上传路径提取、图片类型校验、上传成功/失败 toast 提示。

### 3) 后端：放开分镜帧图更新字段
- 文件：`backend/src/routes/storyboards.ts`
- `PUT /storyboards/:id` 新增字段映射：
  - `first_frame_image` -> `firstFrameImage`
  - `last_frame_image` -> `lastFrameImage`
  - `composed_image` -> `composedImage`
  - `reference_images` -> `referenceImages`
- 使前端上传后的分镜帧路径可被合法写回数据库。

## 兼容性与影响范围
- 向后兼容：是。
- 数据结构迁移：无。
- 默认行为变化：无。仅新增手动上传替换入口，不影响现有 AI 生成流程。

## 验证
### 已完成
- 后端类型检查通过：`npm --prefix backend run typecheck` ✅
- 前端构建通过：`npm --prefix frontend run build` ✅
- 代码链路校验通过：上传接口调用、字段映射写回、页面即时替换与刷新逻辑一致。

### 分支与交付状态
- 当前工作在私有分支：`private/fix-90-local-image-upload`
- 本地已更新完整 PR 描述文件；按要求未创建 GitHub PR。

## 风险评估
- 低风险：改动集中在上传入口与字段映射，不改动 AI 生成核心流程。
- 主要风险点：
  - 用户上传非图片文件（已做 MIME 前端校验，后端由上传接口兜底）。
  - 上传路径为空或异常（已做路径判空并提示）。

## 回归关注点
- 角色图上传后是否即时展示并持久化。
- 分镜首帧/尾帧上传后是否即时展示并参与后续视频生成引用。
- 原有“生成图片”按钮流程是否不受影响。