### PR TITLE
feat: add MiniMax chat model provider with M3 as default

### DIFF
--- a/backend/src/routes/aiConfigs.ts
+++ b/backend/src/routes/aiConfigs.ts
@@ -92,11 +92,13 @@ function buildProbe(serviceType: string, provider: string, baseUrl: string, mode
   }
 
   if (p === 'minimax') {
-    const path = serviceType === 'audio'
-      ? '/t2a_v2'
-      : serviceType === 'video'
-        ? '/video_generation'
-        : '/image_generation'
+    const path = serviceType === 'text'
+      ? '/chat/completions'
+      : serviceType === 'audio'
+        ? '/t2a_v2'
+        : serviceType === 'video'
+          ? '/video_generation'
+          : '/image_generation'
     return {
       method: 'POST',
       url: joinProviderUrl(baseUrl, '/v1', path),

--- a/backend/src/services/__tests__/minimax-provider.test.ts
+++ b/backend/src/services/__tests__/minimax-provider.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for MiniMax text provider support in getTextProviderBaseUrl
+ * Run with: npx tsx src/services/__tests__/minimax-provider.test.ts
+ */
+import assert from 'node:assert'
+import { getTextProviderBaseUrl } from '../ai.js'
+
+type AIConfig = Parameters<typeof getTextProviderBaseUrl>[0]
+
+function makeConfig(provider: string, baseUrl: string): AIConfig {
+  return { provider, baseUrl, apiKey: 'test-key', model: 'MiniMax-M2.7' }
+}
+
+// Test 1: MiniMax provider appends /v1 when baseUrl has no path
+{
+  const config = makeConfig('minimax', 'https://api.minimax.io')
+  const url = getTextProviderBaseUrl(config)
+  assert.strictEqual(url, 'https://api.minimax.io/v1', 'MiniMax base URL should end with /v1')
+  console.log('✓ MiniMax base URL resolves to https://api.minimax.io/v1')
+}
+
+// Test 2: MiniMax is case-insensitive
+{
+  const config = makeConfig('MiniMax', 'https://api.minimax.io')
+  const url = getTextProviderBaseUrl(config)
+  assert.strictEqual(url, 'https://api.minimax.io/v1', 'MiniMax provider name should be case-insensitive')
+  console.log('✓ MiniMax provider name is case-insensitive')
+}
+
+// Test 3: OpenAI still works correctly
+{
+  const config = makeConfig('openai', 'https://api.openai.com')
+  const url = getTextProviderBaseUrl(config)
+  assert.strictEqual(url, 'https://api.openai.com/v1', 'OpenAI base URL should end with /v1')
+  console.log('✓ OpenAI base URL unaffected')
+}
+
+// Test 4: Volcengine still works correctly
+{
+  const config = makeConfig('volcengine', 'https://ark.cn-beijing.volces.com')
+  const url = getTextProviderBaseUrl(config)
+  assert.strictEqual(url, 'https://ark.cn-beijing.volces.com/api/v3', 'Volcengine base URL should end with /api/v3')
+  console.log('✓ Volcengine base URL unaffected')
+}
+
+console.log('\nAll tests passed.')

--- a/backend/src/services/__tests__/minimax-provider.test.ts
+++ b/backend/src/services/__tests__/minimax-provider.test.ts
@@ -8,7 +8,7 @@ import { getTextProviderBaseUrl } from '../ai.js'
 type AIConfig = Parameters<typeof getTextProviderBaseUrl>[0]
 
 function makeConfig(provider: string, baseUrl: string): AIConfig {
-  return { provider, baseUrl, apiKey: 'test-key', model: 'MiniMax-M2.7' }
+  return { provider, baseUrl, apiKey: 'test-key', model: 'MiniMax-M3' }
 }
 
 // Test 1: MiniMax provider appends /v1 when baseUrl has no path

--- a/backend/src/services/ai.ts
+++ b/backend/src/services/ai.ts
@@ -30,6 +30,10 @@ export function getTextProviderBaseUrl(config: AIConfig) {
     return joinProviderUrl(config.baseUrl, '/api/v1', '')
   }
 
+  if (provider === 'minimax') {
+    return joinProviderUrl(config.baseUrl, '/v1', '')
+  }
+
   return config.baseUrl
 }
 

--- a/frontend/app/pages/settings.vue
+++ b/frontend/app/pages/settings.vue
@@ -434,6 +434,7 @@ const providerPresets = {
     chatfire: { label: 'ChatFire 推荐', baseUrl: 'https://api.chatfire.site', models: ['gemini-3-pro-preview'] },
     openrouter: { label: 'OpenRouter 推荐', baseUrl: 'https://openrouter.ai/api', models: ['google/gemini-3-flash-preview'] },
     openai: { label: 'OpenAI 推荐', baseUrl: 'https://api.openai.com', models: ['gpt-4.1-mini'] },
+    minimax: { label: 'MiniMax 推荐', baseUrl: 'https://api.minimax.io', models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] },
   },
   image: {
     chatfire: { label: 'ChatFire 推荐', baseUrl: 'https://api.chatfire.site', models: ['doubao-seedream-4-5-251128'] },

--- a/frontend/app/pages/settings.vue
+++ b/frontend/app/pages/settings.vue
@@ -434,7 +434,7 @@ const providerPresets = {
     chatfire: { label: 'ChatFire 推荐', baseUrl: 'https://api.chatfire.site', models: ['gemini-3-pro-preview'] },
     openrouter: { label: 'OpenRouter 推荐', baseUrl: 'https://openrouter.ai/api', models: ['google/gemini-3-flash-preview'] },
     openai: { label: 'OpenAI 推荐', baseUrl: 'https://api.openai.com', models: ['gpt-4.1-mini'] },
-    minimax: { label: 'MiniMax 推荐', baseUrl: 'https://api.minimax.io', models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] },
+    minimax: { label: 'MiniMax 推荐', baseUrl: 'https://api.minimax.io', models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] },
   },
   image: {
     chatfire: { label: 'ChatFire 推荐', baseUrl: 'https://api.chatfire.site', models: ['doubao-seedream-4-5-251128'] },


### PR DESCRIPTION
## Summary

- Add `minimax` provider support for the **text** service type in AI Agents
- Register the correct base URL (`https://api.minimax.io/v1`) in `getTextProviderBaseUrl()`
- Fix the connectivity probe endpoint for MiniMax text services (use `/chat/completions` instead of `/image_generation`)
- Add MiniMax text provider preset in the Settings UI with `MiniMax-M3` as default, plus `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`
- Add unit tests verifying URL resolution for the new provider

## Models Added

| Model | Description |
|-------|-------------|
| `MiniMax-M3` | 512K context, up to 128K output, supports image input (default) |
| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

## API Reference

- Chat API (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo

## Test Plan

- [x] TypeScript type check passes (`npm run typecheck`)
- [x] Frontend build succeeds (`npm run build`)
- [x] Unit tests for `getTextProviderBaseUrl()` pass
- [x] Integration test: `POST https://api.minimax.io/v1/chat/completions` returns HTTP 200