### PR TITLE
Add Atlas Cloud media provider adapters

### DIFF
--- a/backend/src/routes/aiConfigs.ts
+++ b/backend/src/routes/aiConfigs.ts
@@ -68,6 +68,17 @@ function buildProbe(serviceType: string, provider: string, baseUrl: string, mode
     }
   }
 
+  if (p === 'atlascloud') {
+    return {
+      method: 'GET',
+      url: serviceType === 'text'
+        ? joinProviderUrl(baseUrl, '/v1', '/models')
+        : joinProviderUrl(baseUrl, '/api/v1', '/models'),
+      headers: bearerHeaders(apiKey),
+      body: undefined,
+    }
+  }
+
   if (p === 'ali') {
     return {
       method: 'POST',

--- a/backend/src/services/adapters/atlascloud-image.ts
+++ b/backend/src/services/adapters/atlascloud-image.ts
@@ -1,0 +1,115 @@
+/**
+ * Atlas Cloud Media API image adapter
+ * Endpoint: /api/v1/model/generateImage -> /api/v1/model/result/{request_id}
+ */
+import type {
+  AIConfig,
+  ImageGenResponse,
+  ImageGenerationRecord,
+  ImagePollResponse,
+  ImageProviderAdapter,
+  ProviderRequest,
+} from './types'
+import { joinProviderUrl } from './url'
+
+export class AtlasCloudImageAdapter implements ImageProviderAdapter {
+  provider = 'atlascloud'
+
+  buildGenerateRequest(config: AIConfig, record: ImageGenerationRecord): ProviderRequest {
+    const body = {
+      model: record.model || config.model || 'bytedance/seedream-v5.0-lite',
+      prompt: record.prompt || '',
+      size: this.normalizeSize(record.size || '1920x1080'),
+      output_format: 'png',
+      enable_base64_output: false,
+    }
+
+    return {
+      url: joinProviderUrl(config.baseUrl, '/api/v1', '/model/generateImage'),
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${config.apiKey}`,
+      },
+      body,
+    }
+  }
+
+  parseGenerateResponse(result: any): ImageGenResponse {
+    const data = unwrapData(result)
+    const taskId = data.id || data.request_id
+    if (taskId) return { isAsync: true, taskId }
+
+    const imageUrl = extractFirstOutput(data)
+    if (imageUrl) return { isAsync: false, imageUrl }
+
+    throw new Error(`Unexpected Atlas Cloud image response: ${JSON.stringify(result).slice(0, 200)}`)
+  }
+
+  buildPollRequest(config: AIConfig, taskId: string): ProviderRequest {
+    return {
+      url: joinProviderUrl(config.baseUrl, '/api/v1', `/model/result/${taskId}`),
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${config.apiKey}`,
+      },
+      body: undefined,
+    }
+  }
+
+  parsePollResponse(result: any): ImagePollResponse {
+    const data = unwrapData(result)
+    const status = String(data.status || '').toLowerCase()
+
+    if (['completed', 'succeeded', 'success'].includes(status)) {
+      const imageUrl = extractFirstOutput(data)
+      return imageUrl ? { status: 'completed', imageUrl } : { status: 'completed' }
+    }
+
+    if (['failed', 'canceled', 'cancelled'].includes(status)) {
+      return {
+        status: 'failed',
+        error: data.error || data.message || 'Atlas Cloud image generation failed',
+      }
+    }
+
+    return { status: status === 'pending' ? 'pending' : 'processing' }
+  }
+
+  extractImageUrl(result: any): string | null {
+    return extractFirstOutput(unwrapData(result))
+  }
+
+  extractImageBase64(result: any): { data: string; mimeType: string } | null {
+    const output = extractFirstOutput(unwrapData(result))
+    if (!output?.startsWith('data:image/')) return null
+    const [meta, data] = output.split(',', 2)
+    const mimeType = meta.match(/^data:([^;]+)/)?.[1] || 'image/png'
+    return data ? { data, mimeType } : null
+  }
+
+  private normalizeSize(size: string): string {
+    const normalized = String(size || '').trim().replace('x', '*')
+    const [w, h] = normalized.split('*').map(Number)
+    if (!w || !h) return '2048*2048'
+    const aspect = w / h
+    if (aspect > 1.25) return '2304*1728'
+    if (aspect < 0.8) return '1728*2304'
+    return '2048*2048'
+  }
+}
+
+function unwrapData(result: any) {
+  return result?.data && typeof result.data === 'object' ? result.data : result
+}
+
+function extractFirstOutput(data: any): string | null {
+  const outputs = data?.outputs || data?.output || data?.images || data?.data
+  if (Array.isArray(outputs)) {
+    const first = outputs[0]
+    if (typeof first === 'string') return first
+    return first?.url || first?.image_url || first?.image || null
+  }
+  if (typeof outputs === 'string') return outputs
+  return data?.image_url || data?.url || null
+}

--- a/backend/src/services/adapters/atlascloud-video.ts
+++ b/backend/src/services/adapters/atlascloud-video.ts
@@ -1,0 +1,131 @@
+/**
+ * Atlas Cloud Media API video adapter
+ * Endpoint: /api/v1/model/generateVideo -> /api/v1/model/prediction/{request_id}
+ */
+import type {
+  AIConfig,
+  ProviderRequest,
+  VideoGenResponse,
+  VideoGenerationRecord,
+  VideoPollResponse,
+  VideoProviderAdapter,
+} from './types'
+import { joinProviderUrl } from './url'
+
+export class AtlasCloudVideoAdapter implements VideoProviderAdapter {
+  provider = 'atlascloud'
+
+  buildGenerateRequest(config: AIConfig, record: VideoGenerationRecord): ProviderRequest {
+    const model = this.resolveModel(record, config)
+    const body: Record<string, any> = {
+      model,
+      prompt: record.prompt || '',
+      duration: this.normalizeDuration(record.duration),
+      resolution: '720p',
+      ratio: record.aspectRatio || '16:9',
+      generate_audio: true,
+      watermark: false,
+    }
+
+    if (record.referenceMode === 'single' && record.imageUrl) {
+      body.image = record.imageUrl
+    } else if (record.referenceMode === 'first_last') {
+      if (record.firstFrameUrl) body.image = record.firstFrameUrl
+      if (record.lastFrameUrl) body.last_image = record.lastFrameUrl
+    } else if (record.referenceMode === 'multiple' && record.referenceImageUrls) {
+      try {
+        const refs = JSON.parse(record.referenceImageUrls)
+        body.reference_images = Array.isArray(refs) ? refs : []
+      } catch {
+        body.reference_images = []
+      }
+    }
+
+    return {
+      url: joinProviderUrl(config.baseUrl, '/api/v1', '/model/generateVideo'),
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${config.apiKey}`,
+      },
+      body,
+    }
+  }
+
+  parseGenerateResponse(result: any): VideoGenResponse {
+    const data = unwrapData(result)
+    const taskId = data.id || data.request_id
+    if (taskId) return { isAsync: true, taskId }
+
+    const videoUrl = extractFirstOutput(data)
+    if (videoUrl) return { isAsync: false, videoUrl }
+
+    throw new Error(`Unexpected Atlas Cloud video response: ${JSON.stringify(result).slice(0, 200)}`)
+  }
+
+  buildPollRequest(config: AIConfig, taskId: string): ProviderRequest {
+    return {
+      url: joinProviderUrl(config.baseUrl, '/api/v1', `/model/prediction/${taskId}`),
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${config.apiKey}`,
+      },
+      body: undefined,
+    }
+  }
+
+  parsePollResponse(result: any): VideoPollResponse {
+    const data = unwrapData(result)
+    const status = String(data.status || '').toLowerCase()
+
+    if (['completed', 'succeeded', 'success'].includes(status)) {
+      const videoUrl = extractFirstOutput(data)
+      return videoUrl ? { status: 'completed', videoUrl } : { status: 'completed' }
+    }
+
+    if (['failed', 'canceled', 'cancelled'].includes(status)) {
+      return {
+        status: 'failed',
+        error: data.error || data.message || 'Atlas Cloud video generation failed',
+      }
+    }
+
+    return { status: status === 'pending' ? 'pending' : 'processing' }
+  }
+
+  extractVideoUrl(result: any): string | null {
+    return extractFirstOutput(unwrapData(result))
+  }
+
+  private resolveModel(record: VideoGenerationRecord, config: AIConfig): string {
+    const configured = record.model || config.model || 'bytedance/seedance-2.0-fast/text-to-video'
+    if (record.referenceMode === 'multiple') {
+      return configured.replace(/\/(text|image)-to-video$/, '/reference-to-video')
+    }
+    if (record.imageUrl || record.firstFrameUrl || record.lastFrameUrl) {
+      return configured.replace('/text-to-video', '/image-to-video')
+    }
+    return configured
+  }
+
+  private normalizeDuration(duration?: number | null): number {
+    const parsed = Math.round(Number(duration || 5))
+    if (!Number.isFinite(parsed)) return 5
+    return Math.min(15, Math.max(4, parsed))
+  }
+}
+
+function unwrapData(result: any) {
+  return result?.data && typeof result.data === 'object' ? result.data : result
+}
+
+function extractFirstOutput(data: any): string | null {
+  const outputs = data?.outputs || data?.output || data?.videos || data?.data
+  if (Array.isArray(outputs)) {
+    const first = outputs[0]
+    if (typeof first === 'string') return first
+    return first?.url || first?.video_url || first?.video || null
+  }
+  if (typeof outputs === 'string') return outputs
+  return data?.video_url || data?.url || null
+}

--- a/backend/src/services/adapters/registry.ts
+++ b/backend/src/services/adapters/registry.ts
@@ -12,6 +12,8 @@ import { VolcEngineVideoAdapter } from './volcengine-video'
 import { ViduVideoAdapter } from './vidu-video'
 import { AliImageAdapter } from './ali-image'
 import { AliVideoAdapter } from './ali-video'
+import { AtlasCloudImageAdapter } from './atlascloud-image'
+import { AtlasCloudVideoAdapter } from './atlascloud-video'
 import type { ImageProviderAdapter, VideoProviderAdapter, TTSProviderAdapter } from './types'
 
 // 图片 Adapter 注册表
@@ -21,6 +23,7 @@ export const imageAdapters: Record<string, ImageProviderAdapter> = {
   gemini: new GeminiImageAdapter(),
   volcengine: new VolcEngineImageAdapter(),
   ali: new AliImageAdapter(),
+  atlascloud: new AtlasCloudImageAdapter(),
   // Chatfire - 待确认 API 格式，暂用 OpenAI
   chatfire: new OpenAIImageAdapter(),
 }
@@ -31,6 +34,7 @@ export const videoAdapters: Record<string, VideoProviderAdapter> = {
   volcengine: new VolcEngineVideoAdapter(),
   vidu: new ViduVideoAdapter(),
   ali: new AliVideoAdapter(),
+  atlascloud: new AtlasCloudVideoAdapter(),
   // Chatfire 视频 - 待确认 API 格式
 }
 

--- a/backend/src/services/ai.ts
+++ b/backend/src/services/ai.ts
@@ -18,7 +18,7 @@ export interface AIConfig {
 export function getTextProviderBaseUrl(config: AIConfig) {
   const provider = config.provider.toLowerCase()
 
-  if (provider === 'openai' || provider === 'openrouter' || provider === 'chatfire') {
+  if (provider === 'openai' || provider === 'openrouter' || provider === 'chatfire' || provider === 'atlascloud') {
     return joinProviderUrl(config.baseUrl, '/v1', '')
   }
 

--- a/backend/tests/atlascloud-adapters.test.ts
+++ b/backend/tests/atlascloud-adapters.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+
+import { AtlasCloudImageAdapter } from '../src/services/adapters/atlascloud-image'
+import { AtlasCloudVideoAdapter } from '../src/services/adapters/atlascloud-video'
+import { getImageAdapter, getVideoAdapter } from '../src/services/adapters/registry'
+import { joinProviderUrl } from '../src/services/adapters/url'
+import type { AIConfig } from '../src/services/adapters/types'
+
+const config: AIConfig = {
+  provider: 'atlascloud',
+  baseUrl: 'https://api.atlascloud.ai/api/v1',
+  apiKey: 'test-atlascloud-key',
+  model: '',
+}
+
+const image = new AtlasCloudImageAdapter()
+const imageRequest = image.buildGenerateRequest(config, {
+  id: 1,
+  prompt: 'A cinematic poster for a short drama',
+  size: '1920x1080',
+})
+
+assert.equal(imageRequest.url, 'https://api.atlascloud.ai/api/v1/model/generateImage')
+assert.equal(imageRequest.method, 'POST')
+assert.equal(imageRequest.headers.Authorization, 'Bearer test-atlascloud-key')
+assert.equal(imageRequest.body.model, 'bytedance/seedream-v5.0-lite')
+assert.equal(imageRequest.body.size, '2304*1728')
+assert.equal(imageRequest.body.output_format, 'png')
+assert.equal(imageRequest.body.enable_base64_output, false)
+
+assert.deepEqual(image.parseGenerateResponse({ data: { id: 'img_task_1' } }), {
+  isAsync: true,
+  taskId: 'img_task_1',
+})
+assert.equal(
+  image.buildPollRequest(config, 'img_task_1').url,
+  'https://api.atlascloud.ai/api/v1/model/result/img_task_1',
+)
+assert.deepEqual(image.parsePollResponse({
+  data: { status: 'completed', outputs: [{ url: 'https://cdn.example/image.png' }] },
+}), {
+  status: 'completed',
+  imageUrl: 'https://cdn.example/image.png',
+})
+
+const video = new AtlasCloudVideoAdapter()
+const videoRequest = video.buildGenerateRequest(config, {
+  id: 2,
+  prompt: 'A fast-paced drama trailer',
+  imageUrl: 'https://cdn.example/first-frame.png',
+  referenceMode: 'single',
+  duration: 99,
+  aspectRatio: '9:16',
+})
+
+assert.equal(videoRequest.url, 'https://api.atlascloud.ai/api/v1/model/generateVideo')
+assert.equal(videoRequest.method, 'POST')
+assert.equal(videoRequest.headers.Authorization, 'Bearer test-atlascloud-key')
+assert.equal(videoRequest.body.model, 'bytedance/seedance-2.0-fast/image-to-video')
+assert.equal(videoRequest.body.image, 'https://cdn.example/first-frame.png')
+assert.equal(videoRequest.body.duration, 15)
+assert.equal(videoRequest.body.ratio, '9:16')
+assert.equal(videoRequest.body.watermark, false)
+
+const referenceVideoRequest = video.buildGenerateRequest(config, {
+  id: 3,
+  prompt: 'Keep the same lead actor across shots',
+  referenceMode: 'multiple',
+  referenceImageUrls: JSON.stringify(['https://cdn.example/a.png', 'https://cdn.example/b.png']),
+})
+assert.equal(referenceVideoRequest.body.model, 'bytedance/seedance-2.0-fast/reference-to-video')
+assert.deepEqual(referenceVideoRequest.body.reference_images, [
+  'https://cdn.example/a.png',
+  'https://cdn.example/b.png',
+])
+
+assert.deepEqual(video.parseGenerateResponse({ data: { request_id: 'video_task_1' } }), {
+  isAsync: true,
+  taskId: 'video_task_1',
+})
+assert.equal(
+  video.buildPollRequest(config, 'video_task_1').url,
+  'https://api.atlascloud.ai/api/v1/model/prediction/video_task_1',
+)
+assert.deepEqual(video.parsePollResponse({
+  data: { status: 'succeeded', videos: ['https://cdn.example/video.mp4'] },
+}), {
+  status: 'completed',
+  videoUrl: 'https://cdn.example/video.mp4',
+})
+
+assert.equal(getImageAdapter('atlascloud').provider, 'atlascloud')
+assert.equal(getVideoAdapter('atlascloud').provider, 'atlascloud')
+assert.equal(joinProviderUrl('https://api.atlascloud.ai/v1', '/v1', '/models'), 'https://api.atlascloud.ai/v1/models')
+assert.equal(joinProviderUrl('https://api.atlascloud.ai/api/v1', '/api/v1', '/models'), 'https://api.atlascloud.ai/api/v1/models')
+
+console.log('atlascloud-adapters.test.ts passed')

--- a/frontend/app/pages/settings.vue
+++ b/frontend/app/pages/settings.vue
@@ -421,7 +421,7 @@ const cfgTestResult = ref(null)
 const cfgForm = reactive({ name: '', provider: '', api_key: '', base_url: '', modelStr: '', service_type: 'text', priority: 0 })
 const huobaoForm = reactive({ apiKey: '' })
 const serviceTypes = [{ type: 'text', label: '文本' }, { type: 'image', label: '图片' }, { type: 'video', label: '视频' }, { type: 'audio', label: '音频' }]
-const providers = ['ali', 'chatfire', 'gemini', 'minimax', 'openai', 'openrouter', 'vidu', 'volcengine']
+const providers = ['ali', 'atlascloud', 'chatfire', 'gemini', 'minimax', 'openai', 'openrouter', 'vidu', 'volcengine']
 const providerSelectOptions = computed(() => providers.map(p => ({ label: p, value: p })))
 const serviceMeta = {
   text: { label: '文本', desc: '剧本改写、角色场景提取、分镜拆解等 Agent 文本能力' },
@@ -431,16 +431,19 @@ const serviceMeta = {
 }
 const providerPresets = {
   text: {
+    atlascloud: { label: 'Atlas Cloud 推荐', baseUrl: 'https://api.atlascloud.ai/v1', models: ['qwen/qwen3.5-flash'] },
     chatfire: { label: 'ChatFire 推荐', baseUrl: 'https://api.chatfire.site', models: ['gemini-3-pro-preview'] },
     openrouter: { label: 'OpenRouter 推荐', baseUrl: 'https://openrouter.ai/api', models: ['google/gemini-3-flash-preview'] },
     openai: { label: 'OpenAI 推荐', baseUrl: 'https://api.openai.com', models: ['gpt-4.1-mini'] },
   },
   image: {
+    atlascloud: { label: 'Atlas Cloud 推荐', baseUrl: 'https://api.atlascloud.ai/api/v1', models: ['bytedance/seedream-v5.0-lite'] },
     chatfire: { label: 'ChatFire 推荐', baseUrl: 'https://api.chatfire.site', models: ['doubao-seedream-4-5-251128'] },
     gemini: { label: 'Gemini 推荐', baseUrl: 'https://api.chatfire.site', models: ['gemini-3-pro-image-preview'] },
     volcengine: { label: '火山推荐', baseUrl: 'https://ark.cn-beijing.volces.com', models: ['doubao-seedream-4-0-250828'] },
   },
   video: {
+    atlascloud: { label: 'Atlas Cloud 推荐', baseUrl: 'https://api.atlascloud.ai/api/v1', models: ['bytedance/seedance-2.0-fast/text-to-video'] },
     volcengine: { label: '火宝视频', baseUrl: 'https://api.chatfire.site/volcengine', models: ['doubao-seedance-1-5-pro-251215'] },
     vidu: { label: 'Vidu 推荐', baseUrl: 'https://api.vidu.com', models: ['viduq3-turbo'] },
     ali: { label: '阿里推荐', baseUrl: 'https://dashscope.aliyuncs.com', models: ['wan2.6-i2v-flash'] },
@@ -468,9 +471,13 @@ const endpointPrefixes = {
 
 const endpointHint = computed(() => {
   const provider = cfgForm.provider
-  const base = cfgForm.base_url || 'https://...'
-  const prefix = endpointPrefixes[provider] || ''
   if (!provider) return '选择服务商后显示推荐端点前缀'
+  const base = (cfgForm.base_url || 'https://...').replace(/\/$/, '')
+  if (provider === 'atlascloud') {
+    const prefix = cfgForm.service_type === 'text' ? '/v1' : '/api/v1'
+    return base.endsWith(prefix) ? base : `${base}${prefix}`
+  }
+  const prefix = endpointPrefixes[provider] || ''
   return `${base}${prefix}`
 })
 


### PR DESCRIPTION
## Summary
- add Atlas Cloud image and video adapters using the existing provider adapter registry
- add Atlas Cloud presets in the settings UI for text, image, and video services
- route Atlas Cloud text configs through the OpenAI-compatible /v1 endpoint and media configs through /api/v1
- add focused adapter tests for request construction, polling response parsing, registry registration, and URL prefix handling

## Validation
- npm run typecheck (backend)
- npx tsx tests/atlascloud-adapters.test.ts (backend)
- npm run build (frontend)
- git diff --check
- live Atlas Cloud model catalog check for qwen/qwen3.5-flash, bytedance/seedream-v5.0-lite, and bytedance/seedance-2.0-fast/text-to-video

## README / promotion compliance
- No README changes
- No sponsor, logo, credits, or partner promotion changes