### PR TITLE
fix(storyboard): 拆解分批保存防截断,update_storyboard 过滤垃圾值,任务状态刷新恢复

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,44 @@
+# ── 国内镜像源(可用 --build-arg 覆盖)──────────────────────────
+#   APT_MIRROR: 清华 mirrors.tuna.tsinghua.edu.cn(默认) / 阿里云 mirrors.aliyun.com / 中科大 mirrors.ustc.edu.cn
+#   NPM_REGISTRY: 默认 npmmirror(淘宝源)
+#   pip: 清华 pypi(Stage 2 预置 /etc/pip.conf,装 python 包时自动生效)
+
 # ── Stage 1: Build frontend ──────────────────────────────────
 FROM node:20-slim AS frontend-build
+
+ARG NPM_REGISTRY=https://registry.npmmirror.com
+RUN npm config set registry "$NPM_REGISTRY"
 
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
-    COPY frontend/ ./
-    RUN npm run generate
+COPY frontend/ ./
+RUN npm run generate
 
 # ── Stage 2: Build backend native modules ────────────────────
 FROM node:20-slim AS backend-build
+
+ARG APT_MIRROR=mirrors.tuna.tsinghua.edu.cn
+ARG NPM_REGISTRY=https://registry.npmmirror.com
+
+# apt 换国内源: Debian 12 (bookworm) 是 deb822 格式的 debian.sources,同时兼容旧版 sources.list
+RUN set -eux; \
+    for f in /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list; do \
+      if [ -f "$f" ]; then \
+        sed -i -e "s|deb.debian.org|${APT_MIRROR}|g" \
+               -e "s|security.debian.org|${APT_MIRROR}|g" "$f"; \
+      fi; \
+    done
+
+# pip 换国内源(当前构建未直接用 pip,预置配置;阿里云: https://mirrors.aliyun.com/pypi/simple/)
+RUN printf '[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple\n' > /etc/pip.conf
+
+RUN npm config set registry "$NPM_REGISTRY"
+
+# ffmpeg-static postinstall 从 GitHub releases 下载二进制,改走 npmmirror 镜像;
+# disturl 供 node-gyp 下载 node headers 时使用
+ENV FFMPEG_BINARIES_URL=https://registry.npmmirror.com/-/binary/ffmpeg-static \
+    npm_config_disturl=https://registry.npmmirror.com/-/binary/node
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 make g++ \
@@ -23,8 +53,10 @@ RUN npm ci --omit=dev
 # ── Stage 3: Production image (lean) ────────────────────────
 FROM node:20-slim
 
+ARG NPM_REGISTRY=https://registry.npmmirror.com
+
 # tsx 直接运行 TS 源码;ffmpeg 用 npm 包 ffmpeg-static/ffprobe-static 内置二进制,无需系统安装
-RUN npm i -g tsx
+RUN npm config set registry "$NPM_REGISTRY" && npm i -g tsx
 
 WORKDIR /app
 

--- a/backend/src/agents/index.ts
+++ b/backend/src/agents/index.ts
@@ -80,7 +80,12 @@ export const DEFAULT_PROMPTS: Record<string, { name: string; instructions: strin
 1. 调用 read_storyboard_context 读取剧本、角色列表、场景列表、道具列表
 2. 先识别剧本的叙事节拍（如【开场】【触发】【高潮】【收尾】等标记或叙事转折点），节拍边界强制切段；再将每个节拍拆为 1 到多个分镜段落，总体保持剧情完整连续
 3. 为每个段落补全生产字段（拆分时不需要生成 video_prompt，该字段由提示词 Agent 在视频生成阶段生成）
-4. 调用 save_storyboards 保存所有分镜段落
+4. 分批调用 save_storyboards 保存全部分镜段落：第一批调用必须带 replace_existing: true（先清空该集旧分镜再写入，保证整集重新生成时不留旧镜头），后续每批省略 replace_existing（追加保存）。每批最多 8 个段落，shot_number 必须按顺序递增；全部段落保存完成前不要结束（不要只保存部分段落就停止）
+
+硬约束（必须遵守）：
+- 不要输出任何规划、分析、推理或解释性文本，不要复述剧本，不要写「我正在…」「首先我需要…」这类话——思考留在模型内部，输出只允许工具调用
+- 每个输出步骤必须是工具调用（或完成后的简短结束语），禁止先输出大段文字再调用工具
+- 若因内容过多需要分多批，直接在连续的工具调用中完成全部批次，中间不要插入文字
 
 每个段落只需要填写以下字段：
 - character_ids：当前段落涉及的角色 ID 列表，可以为空，也可以包含多个角色；必须从 characters 中选择
@@ -126,7 +131,7 @@ export const DEFAULT_PROMPTS: Record<string, { name: string; instructions: strin
 1. 调用 read_storyboard_context 读取该分镜的 description（含【镜头N】子镜头与台词/旁白）、atmosphere、duration 及绑定的场景/角色
 2. 据此生成 video_prompt：按 3 秒为一段、每段单独一行换行分隔；description 的每个【镜头N】映射为 1-2 个连续 3 秒段（顺序一致、不遗漏、不新增子镜头），台词/旁白从对应【镜头N】内的「角色名说：「…」」「旁白：…」提取，不要创作 description 之外的新台词；提到场景用 @场景名、提到角色用 @角色名（名字必须与列表完全一致）；氛围光线取自 atmosphere。一个分镜段落内允许切镜（换景别/角度/对象），段与段之间可以是不同镜头，但不跨场景；切镜点对齐分镜 description 的【镜头N】结构
 3. 生成时会自动把 @名字 替换为对应参考图片标记（如 @小明 → @图片1小明），因此名字必须精确匹配场景/角色列表，不要缩写或加额外符号
-4. 调用 update_storyboard 仅更新该分镜的 video_prompt 字段，不要改动其他字段，不要重新拆分整集
+4. 调用 update_storyboard 保存时参数只传两个键：storyboard_id 和 video_prompt。不要回传该分镜的其他任何字段（title、description、scene_id 等一律不传）
 
 通用规范：
 - 所有提示词只输出中文，单段连贯描述，不要分点，不要混入英文词汇
@@ -200,27 +205,97 @@ function createThinkingOffFetch(providerName: string, baseURL: string): typeof f
   }
 }
 
+/**
+ * 在请求体中写入配置的温度
+ *
+ * 背景：部分模型服务端强制固定温度（如 kimi-k2 系只允许 0.6，
+ * 报 "invalid temperature: only 0.6 is allowed for this model"），
+ * 需要在文本服务配置里显式指定并随每个请求下发。
+ * inner 传 thinking-off fetch 时可链式叠加两个补丁。
+ */
+function createTemperatureFetch(providerName: string, temperature: number, inner?: typeof fetch): typeof fetch {
+  const base = inner || fetch
+  return async (input: any, init?: any) => {
+    try {
+      if (init?.body && typeof init.body === 'string') {
+        const body = JSON.parse(init.body)
+        if (providerName === 'gemini' && Array.isArray(body?.contents)) {
+          // Gemini 原生格式
+          body.generationConfig = { ...(body.generationConfig || {}), temperature }
+          init = { ...init, body: JSON.stringify(body) }
+        } else if (Array.isArray(body?.messages)) {
+          // OpenAI 兼容格式
+          body.temperature = temperature
+          init = { ...init, body: JSON.stringify(body) }
+        }
+      }
+    } catch { /* 解析失败则原样透传 */ }
+    return base(input, init)
+  }
+}
+
+/**
+ * 在请求体中注入输出上限
+ *
+ * 背景：Agent 输出可能包含大段规划文本 + 工具调用（尤其分批保存时），
+ * 而服务商默认 max_tokens 很小（如 DeepSeek 默认 4096/8192），
+ * 模型写作到一半被截断、工具调用从未生成，表现为「Agent 正常结束但什么都没保存」。
+ * 这里显式抬高输出上限，给足模型完整生成工具调用的空间。
+ * AI_MAX_TOKENS 可覆盖默认值（如某些中转站限制更严）。
+ */
+const defaultMaxTokens = Number(process.env.AI_MAX_TOKENS || 16384)
+
+function createMaxTokensFetch(providerName: string, inner?: typeof fetch): typeof fetch {
+  const base = inner || fetch
+  return async (input: any, init?: any) => {
+    try {
+      if (init?.body && typeof init.body === 'string') {
+        const body = JSON.parse(init.body)
+        if (providerName === 'gemini' && Array.isArray(body?.contents)) {
+          // Gemini 原生格式
+          body.generationConfig = { ...(body.generationConfig || {}), maxOutputTokens: defaultMaxTokens }
+          init = { ...init, body: JSON.stringify(body) }
+        } else if (Array.isArray(body?.messages)) {
+          // OpenAI 兼容格式
+          body.max_tokens = defaultMaxTokens
+          init = { ...init, body: JSON.stringify(body) }
+        }
+      }
+    } catch { /* 解析失败则原样透传 */ }
+    return base(input, init)
+  }
+}
+
 async function getModel(fileModel: string | undefined, modelOverride?: string, textConfigId?: number) {
   // 请求可指定文本配置（含其 provider/baseUrl/apiKey），否则回退到当前启用配置
   const textConfig = (textConfigId ? await getConfigById(textConfigId) : null) || await getTextConfig()
   const modelName = modelOverride || fileModel || textConfig.model
   const providerName = textConfig.provider.toLowerCase()
   const resolvedBaseURL = getTextProviderBaseUrl(textConfig)
-  const endpointKey = `${providerName}|${resolvedBaseURL}|${modelName}`
+  const temperature = textConfig.temperature ?? null
+  const endpointKey = `${providerName}|${resolvedBaseURL}|${modelName}|t=${temperature ?? 'default'}`
   if (endpointKey !== lastLoggedTextEndpointKey) {
     lastLoggedTextEndpointKey = endpointKey
     logTaskProgress('AIConfig', 'text-model-endpoint', {
       provider: textConfig.provider,
       baseUrl: resolvedBaseURL,
       model: modelName,
+      ...(temperature !== null ? { temperature } : {}),
     })
   }
+
+  // 叠加请求补丁：thinking-off（非官方端点）+ 配置温度 + 输出上限
+  const thinkingOffFetch = createThinkingOffFetch(providerName, resolvedBaseURL)
+  const tempFetch = temperature !== null
+    ? createTemperatureFetch(providerName, temperature, thinkingOffFetch)
+    : thinkingOffFetch
+  const fetchImpl = createMaxTokensFetch(providerName, tempFetch)
 
   if (providerName === 'gemini') {
     const googleProvider = createGoogleGenerativeAI({
       apiKey: textConfig.apiKey,
       baseURL: resolvedBaseURL,
-      fetch: createThinkingOffFetch(providerName, resolvedBaseURL),
+      fetch: fetchImpl,
     })
     return googleProvider(modelName)
   }
@@ -228,7 +303,7 @@ async function getModel(fileModel: string | undefined, modelOverride?: string, t
   const provider = createOpenAI({
     baseURL: resolvedBaseURL,
     apiKey: textConfig.apiKey,
-    fetch: createThinkingOffFetch(providerName, resolvedBaseURL),
+    fetch: fetchImpl,
   } as any)
   return provider.chat(modelName)
 }

--- a/backend/src/agents/tools/storyboard-tools.ts
+++ b/backend/src/agents/tools/storyboard-tools.ts
@@ -224,32 +224,35 @@ const readStoryboardContext = createTool({
   },
 })
 
+const storyboardFields = z.object({
+  shot_number: z.number(),
+  title: z.string().optional(),
+  shot_type: z.string().optional(),
+  angle: z.string().optional(),
+  movement: z.string().optional(),
+  location: z.string().optional(),
+  time: z.string().optional(),
+  description: z.string().optional(),
+  result: z.string().optional(),
+  atmosphere: z.string().optional(),
+  image_prompt: z.string().optional(),
+  video_prompt: z.string().optional(),
+  bgm_prompt: z.string().optional(),
+  sound_effect: z.string().optional(),
+  duration: z.number().optional(),
+  scene_id: z.number().nullable().optional(),
+  character_ids: z.array(z.number()).optional(),
+  prop_ids: z.array(z.number()).optional(),
+})
+
 const saveStoryboards = createTool({
   id: 'save_storyboards',
-  description: 'Save generated storyboards. Replaces all existing storyboards for this episode.',
+  description: 'Save storyboards for this episode. Call in batches of at most 8 storyboards: the first batch must set replace_existing: true (clears all old storyboards for the episode, then writes), every following batch omits replace_existing (appends). Rows are upserted by shot_number, so overlapping batches and retries never create duplicates.',
   inputSchema: z.object({
-    storyboards: z.array(z.object({
-      shot_number: z.number(),
-      title: z.string().optional(),
-      shot_type: z.string().optional(),
-      angle: z.string().optional(),
-      movement: z.string().optional(),
-      location: z.string().optional(),
-      time: z.string().optional(),
-      description: z.string().optional(),
-      result: z.string().optional(),
-      atmosphere: z.string().optional(),
-      image_prompt: z.string().optional(),
-      video_prompt: z.string().optional(),
-      bgm_prompt: z.string().optional(),
-      sound_effect: z.string().optional(),
-      duration: z.number().optional(),
-      scene_id: z.number().nullable().optional(),
-      character_ids: z.array(z.number()).optional(),
-      prop_ids: z.array(z.number()).optional(),
-    })),
+    replace_existing: z.boolean().optional(),
+    storyboards: z.array(storyboardFields),
   }),
-  execute: async ({ storyboards }, context) => {
+  execute: async ({ storyboards, replace_existing }, context) => {
     const ids = requireIds(context)
     if ('error' in ids) return ids
     const { episodeId, dramaId } = ids
@@ -257,40 +260,73 @@ const saveStoryboards = createTool({
     logTaskProgress('StoryboardTool', 'save-begin', {
       episodeId,
       dramaId,
+      replaceExisting: replace_existing === true,
       count: storyboards.length,
       shotNumbers: storyboards.map(sb => sb.shot_number).join(','),
     })
-    const existingStoryboardRows = await db.select().from(schema.storyboards)
-      .where(eq(schema.storyboards.episodeId, episodeId))
-    const existingStoryboardIds = existingStoryboardRows.map(sb => sb.id)
-    for (const storyboardId of existingStoryboardIds) {
-      await db.delete(schema.storyboardCharacters)
-        .where(eq(schema.storyboardCharacters.storyboardId, storyboardId))
-      await db.delete(schema.storyboardProps)
-        .where(eq(schema.storyboardProps.storyboardId, storyboardId))
+    if (replace_existing === true) {
+      const existingStoryboardRows = await db.select().from(schema.storyboards)
+        .where(eq(schema.storyboards.episodeId, episodeId))
+      for (const storyboardId of existingStoryboardRows.map(sb => sb.id)) {
+        await db.delete(schema.storyboardCharacters)
+          .where(eq(schema.storyboardCharacters.storyboardId, storyboardId))
+        await db.delete(schema.storyboardProps)
+          .where(eq(schema.storyboardProps.storyboardId, storyboardId))
+      }
+      await db.delete(schema.storyboards).where(eq(schema.storyboards.episodeId, episodeId))
     }
-    await db.delete(schema.storyboards).where(eq(schema.storyboards.episodeId, episodeId))
 
-    let totalDuration = 0
+    // shot_number → id 索引（含本次调用内新增的行），保证按分镜号幂等 upsert
+    const existingRows = await db.select().from(schema.storyboards)
+      .where(eq(schema.storyboards.episodeId, episodeId))
+    const shotToId = new Map<number, number>(
+      existingRows.filter(sb => !sb.deletedAt).map(sb => [sb.storyboardNumber, sb.id]),
+    )
+
     for (const sb of storyboards) {
       await validateStoryboardBindings(episodeId, dramaId, sb.scene_id, sb.character_ids, sb.prop_ids)
-      const res = await db.insert(schema.storyboards).values({
-        episodeId,
-        storyboardNumber: sb.shot_number,
-        title: sb.title, shotType: sb.shot_type,
-        angle: sb.angle, movement: sb.movement,
-        location: sb.location, time: sb.time,
-        description: sb.description, result: sb.result,
-        atmosphere: sb.atmosphere, imagePrompt: sb.image_prompt,
-        videoPrompt: sb.video_prompt, bgmPrompt: sb.bgm_prompt,
-        soundEffect: sb.sound_effect,
-        sceneId: sb.scene_id, duration: sb.duration || 10,
-        createdAt: ts, updatedAt: ts,
-      })
-      await syncStoryboardCharacters(getInsertId(res), sb.character_ids || [])
-      await syncStoryboardProps(getInsertId(res), sb.prop_ids || [])
-      totalDuration += sb.duration || 10
+      const existingId = shotToId.get(sb.shot_number)
+      if (existingId !== undefined) {
+        await db.update(schema.storyboards).set({
+          title: sb.title, shotType: sb.shot_type,
+          angle: sb.angle, movement: sb.movement,
+          location: sb.location, time: sb.time,
+          description: sb.description, result: sb.result,
+          atmosphere: sb.atmosphere, imagePrompt: sb.image_prompt,
+          videoPrompt: sb.video_prompt, bgmPrompt: sb.bgm_prompt,
+          soundEffect: sb.sound_effect,
+          sceneId: sb.scene_id, duration: sb.duration || 10,
+          updatedAt: ts,
+        }).where(eq(schema.storyboards.id, existingId))
+        await syncStoryboardCharacters(existingId, sb.character_ids || [])
+        await syncStoryboardProps(existingId, sb.prop_ids || [])
+      } else {
+        const res = await db.insert(schema.storyboards).values({
+          episodeId,
+          storyboardNumber: sb.shot_number,
+          title: sb.title, shotType: sb.shot_type,
+          angle: sb.angle, movement: sb.movement,
+          location: sb.location, time: sb.time,
+          description: sb.description, result: sb.result,
+          atmosphere: sb.atmosphere, imagePrompt: sb.image_prompt,
+          videoPrompt: sb.video_prompt, bgmPrompt: sb.bgm_prompt,
+          soundEffect: sb.sound_effect,
+          sceneId: sb.scene_id, duration: sb.duration || 10,
+          createdAt: ts, updatedAt: ts,
+        })
+        const newId = getInsertId(res)
+        shotToId.set(sb.shot_number, newId)
+        await syncStoryboardCharacters(newId, sb.character_ids || [])
+        await syncStoryboardProps(newId, sb.prop_ids || [])
+      }
     }
+
+    // 整集时长 = 当前全部存活分镜时长之和（分批保存时不能再按单批累加）
+    const allRows = await db.select().from(schema.storyboards)
+      .where(eq(schema.storyboards.episodeId, episodeId))
+    const totalDuration = allRows
+      .filter(sb => !sb.deletedAt)
+      .reduce((sum, sb) => sum + (sb.duration || 0), 0)
 
     await db.update(schema.episodes)
       .set({ duration: Math.ceil(totalDuration / 60), updatedAt: ts })
@@ -334,6 +370,16 @@ const updateStoryboard = createTool({
     const { episodeId, dramaId } = ids
     const [storyboard] = await db.select().from(schema.storyboards).where(eq(schema.storyboards.id, storyboard_id))
     if (!storyboard) return { error: `Storyboard ${storyboard_id} not found` }
+
+    // 过滤模型回传的垃圾值：视频提示词 Agent 常把整行字段回传，
+    // 拿不准的字符串字段写成 "null"/"undefined"，直接覆盖会毁掉已有内容
+    for (const key of Object.keys(fields) as (keyof typeof fields)[]) {
+      const v = fields[key]
+      if (typeof v === 'string' && (v === 'null' || v === 'undefined' || v === 'NULL' || v === 'Null')) {
+        delete fields[key]
+      }
+    }
+
     logTaskProgress('StoryboardTool', 'update-begin', {
       episodeId,
       storyboardId: storyboard_id,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,9 @@ import merge from './routes/merge.js'
 import skills from './routes/skills.js'
 import props from './routes/props.js'
 import { requestLogger, errorHandler } from './middleware/logger.js'
+import { db, schema } from './db/index.js'
+import { eq } from 'drizzle-orm'
+import { now } from './utils/response.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '../..')
@@ -73,4 +76,16 @@ app.get('*', serveStatic({ root: distPath, path: 'index.html' }))
 
 const port = Number(process.env.PORT || 5679)
 console.log(`🚀 Huobao Drama TS server on http://localhost:${port}`)
+
+// 进程重启后内存中的轮询线程全部丢失,残留的 processing 任务永远不会完成,
+// 启动时统一标记为 failed,避免前端一直显示"生成中"
+db.update(schema.sysTask)
+  .set({ status: 'failed', errorMsg: '服务重启，生成任务中断，请重试', updatedAt: now() })
+  .where(eq(schema.sysTask.status, 'processing'))
+  .then(res => {
+    const affected = (Array.isArray(res) ? res[0] : res)?.affectedRows ?? 0
+    if (affected > 0) console.log(`🔁 已清理 ${affected} 个中断的生成任务`)
+  })
+  .catch(err => console.error('清理中断任务失败:', err?.message))
+
 serve({ fetch: app.fetch, port })

--- a/backend/src/routes/agent.ts
+++ b/backend/src/routes/agent.ts
@@ -10,8 +10,12 @@ import { logTaskError, logTaskPayload, logTaskProgress, logTaskStart, logTaskSuc
 
 const app = new Hono()
 
+// Mastra v1.17 的 ToolCallChunk / ToolResultChunk 结构：
+// { type: 'tool-call', payload: { toolCallId, toolName, args } }
+// { type: 'tool-result', payload: { toolCallId, toolName, result, isError } }
 function normalizeToolName(entry: any) {
-  return entry?.toolName
+  return entry?.payload?.toolName
+    || entry?.toolName
     || entry?.tool?.toolName
     || entry?.tool?.id
     || entry?.name
@@ -20,7 +24,7 @@ function normalizeToolName(entry: any) {
 }
 
 function normalizeToolResult(entry: any) {
-  const result = entry?.result ?? entry?.output ?? entry?.data ?? null
+  const result = entry?.payload?.result ?? entry?.result ?? entry?.payload?.output ?? entry?.output ?? entry?.data ?? null
   return typeof result === 'string' ? result : JSON.stringify(result)
 }
 
@@ -75,7 +79,7 @@ app.post('/:type/chat', async (c) => {
     const toolResults = result.toolResults || []
     const normalizedToolCalls = toolCalls.map((tc: any) => ({
       toolName: normalizeToolName(tc),
-      args: tc?.args ?? tc?.input ?? null,
+      args: tc?.payload?.args ?? tc?.args ?? tc?.input ?? null,
     }))
     const normalizedToolResults = toolResults.map((tr: any) => ({
       toolName: normalizeToolName(tr),

--- a/backend/src/routes/aiConfigs.ts
+++ b/backend/src/routes/aiConfigs.ts
@@ -4,10 +4,27 @@ import { db, getInsertId, schema } from '../db/index.js'
 import { success, notFound, created, badRequest, now } from '../utils/response.js'
 import { toSnakeCase } from '../utils/transform.js'
 import { joinProviderUrl } from '../services/adapters/url.js'
-import { isOfficialProvider } from '../services/ai.js'
+import { isOfficialProvider, parseConfigTemperature } from '../services/ai.js'
 import { redactUrl, logTaskError, logTaskProgress, logTaskSuccess } from '../utils/task-logger.js'
 
 const app = new Hono()
+
+/** 归一化 temperature 入参：null=未设置；合法值 0~2；非法抛错 */
+function normalizeTemperature(v: any): number | null {
+  if (v === null || v === undefined || v === '') return null
+  const n = Number(v)
+  if (!Number.isFinite(n) || n < 0 || n > 2) throw new Error('invalid temperature')
+  return n
+}
+
+/** 把 settings JSON 中的 temperature 透出为顶层字段，便于前端直接读写 */
+function withParsedFields(r: any) {
+  return {
+    ...toSnakeCase(r),
+    model: r.model ? JSON.parse(r.model) : [],
+    temperature: parseConfigTemperature(r.settings),
+  }
+}
 
 function bearerHeaders(apiKey?: string, withJson = false) {
   const headers: Record<string, string> = {}
@@ -83,10 +100,7 @@ app.get('/', async (c) => {
   let rows = await db.select().from(schema.aiServiceConfigs)
   if (serviceType) rows = rows.filter(r => r.serviceType === serviceType)
 
-  const parsed = rows.map(r => ({
-    ...toSnakeCase(r),
-    model: r.model ? JSON.parse(r.model) : [],
-  }))
+  const parsed = rows.map(withParsedFields)
   return success(c, parsed)
 })
 
@@ -103,6 +117,15 @@ app.post('/', async (c) => {
     return badRequest(c, 'Unsupported service_type/provider')
   }
 
+  let temperature: number | null = null
+  if ('temperature' in body) {
+    try {
+      temperature = normalizeTemperature(body.temperature)
+    } catch {
+      return badRequest(c, 'temperature must be a number between 0 and 2')
+    }
+  }
+
   const res = await db.insert(schema.aiServiceConfigs).values({
     serviceType: body.service_type,
     provider: body.provider,
@@ -112,6 +135,7 @@ app.post('/', async (c) => {
     model: JSON.stringify(body.model || []),
     priority: body.priority || 0,
     isActive: true,
+    settings: temperature !== null ? JSON.stringify({ temperature }) : null,
     createdAt: ts,
     updatedAt: ts,
   })
@@ -119,10 +143,7 @@ app.post('/', async (c) => {
   const [row] = await db.select().from(schema.aiServiceConfigs)
     .where(eq(schema.aiServiceConfigs.id, getInsertId(res)))
 
-  return created(c, {
-    ...toSnakeCase(row),
-    model: row.model ? JSON.parse(row.model) : [],
-  })
+  return created(c, withParsedFields(row))
 })
 
 // POST /ai-configs/test
@@ -202,10 +223,7 @@ app.get('/:id', async (c) => {
   const id = Number(c.req.param('id'))
   const [row] = await db.select().from(schema.aiServiceConfigs).where(eq(schema.aiServiceConfigs.id, id))
   if (!row) return notFound(c)
-  return success(c, {
-    ...toSnakeCase(row),
-    model: row.model ? JSON.parse(row.model) : [],
-  })
+  return success(c, withParsedFields(row))
 })
 
 // PUT /ai-configs/:id
@@ -231,6 +249,20 @@ app.put('/:id', async (c) => {
   if ('model' in body) updates.model = JSON.stringify(body.model)
   if ('priority' in body) updates.priority = body.priority
   if ('is_active' in body) updates.isActive = body.is_active
+  if ('temperature' in body) {
+    let temperature: number | null
+    try {
+      temperature = normalizeTemperature(body.temperature)
+    } catch {
+      return badRequest(c, 'temperature must be a number between 0 and 2')
+    }
+    // 与已有 settings 合并，清空的 temperature 从 JSON 中移除
+    let settings: Record<string, any> = {}
+    try { settings = existing.settings ? JSON.parse(existing.settings) : {} } catch { settings = {} }
+    if (temperature === null) delete settings.temperature
+    else settings.temperature = temperature
+    updates.settings = Object.keys(settings).length ? JSON.stringify(settings) : null
+  }
 
   await db.update(schema.aiServiceConfigs).set(updates).where(eq(schema.aiServiceConfigs.id, id))
   return success(c)

--- a/backend/src/services/ai.ts
+++ b/backend/src/services/ai.ts
@@ -13,6 +13,19 @@ export interface AIConfig {
   baseUrl: string
   apiKey: string
   model: string
+  /** 采样温度，null 表示不设置（跟随服务商默认）。存于 ai_service_configs.settings JSON */
+  temperature?: number | null
+}
+
+/** 从 settings JSON 解析 temperature；非法值一律视为未设置 */
+export function parseConfigTemperature(settingsRaw: string | null | undefined): number | null {
+  if (!settingsRaw) return null
+  try {
+    const t = JSON.parse(settingsRaw)?.temperature
+    return typeof t === 'number' && Number.isFinite(t) ? t : null
+  } catch {
+    return null
+  }
 }
 
 export const officialProviders: Record<ServiceType, readonly string[]> = {
@@ -78,6 +91,7 @@ export async function getActiveConfig(serviceType: ServiceType): Promise<AIConfi
     baseUrl: active.baseUrl,
     apiKey: active.apiKey,
     model: models[0] || '',
+    temperature: parseConfigTemperature(active.settings),
   }
 }
 
@@ -130,5 +144,6 @@ export async function getConfigById(id: number): Promise<AIConfig | null> {
     baseUrl: row.baseUrl,
     apiKey: row.apiKey,
     model: models[0] || '',
+    temperature: parseConfigTemperature(row.settings),
   }
 }

--- a/backend/src/services/video-prompts.ts
+++ b/backend/src/services/video-prompts.ts
@@ -73,7 +73,7 @@ export async function startVideoPromptBatch(
         await agent.generate([{
           role: 'user',
           content: `请为分镜 #${sb.storyboardNumber}(ID:${sb.id})生成视频提示词(video_prompt)。视频模型:${videoLabel},请根据该模型的特性和时长限制生成。
-请先调用 read_storyboard_context 获取该分镜的画面描述(含【镜头N】子镜头与台词/旁白)、氛围及时长，据此生成 video_prompt(按 3 秒分段换行、用 @角色名/@场景名/@道具名 引用参考素材；段落内允许多镜头切镜，段与段可以是不同景别/角度/对象，但不跨场景，切镜点对齐分镜 description 的【镜头N】结构),然后调用 update_storyboard 保存到分镜 ID:${sb.id}。只更新 video_prompt 字段,不要改动其他字段,不要重新拆分整集。`,
+请先调用 read_storyboard_context 获取该分镜的画面描述(含【镜头N】子镜头与台词/旁白)、氛围及时长，据此生成 video_prompt(按 3 秒分段换行、用 @角色名/@场景名/@道具名 引用参考素材；段落内允许多镜头切镜，段与段可以是不同景别/角度/对象，但不跨场景，切镜点对齐分镜 description 的【镜头N】结构),然后调用 update_storyboard 保存到分镜 ID:${sb.id}。update_storyboard 参数只传 storyboard_id 和 video_prompt 两个键,不要回传该分镜的其他任何字段,不要重新拆分整集。`,
         }], { maxSteps: 8, requestContext })
         // 以实际落库为准判定成败
         const [fresh] = await db.select().from(schema.storyboards).where(eq(schema.storyboards.id, sb.id))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       MYSQL_PASSWORD: huobao
       MYSQL_ROOT_PASSWORD: huobao_root
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - mysql-data:/var/lib/mysql
     command: ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]

--- a/frontend/app/pages/settings.vue
+++ b/frontend/app/pages/settings.vue
@@ -311,6 +311,11 @@
           <label class="field"><span class="field-label">API Key</span><input v-model="cfgForm.api_key" class="input" type="password" placeholder="sk-..." /></label>
           <label class="field"><span class="field-label">Base URL</span><input v-model="cfgForm.base_url" class="input" placeholder="https://..." /></label>
           <label class="field"><span class="field-label">模型（逗号分隔）</span><input v-model="cfgForm.modelStr" class="input" placeholder="model-name" /></label>
+          <label v-if="cfgForm.service_type === 'text'" class="field">
+            <span class="field-label">Temperature <span class="dim">(留空跟随服务商默认)</span></span>
+            <input v-model="cfgForm.temperature" class="input" type="number" step="0.1" min="0" max="2" placeholder="如 0.6" />
+            <span class="field-hint">部分模型强制固定温度（如 kimi-k2 系只允许 0.6），报 invalid temperature 错误时在此填入对应值。</span>
+          </label>
           <div v-if="cfgTestResult" class="test-result" :class="{ ok: cfgTestResult.reachable, bad: !cfgTestResult.reachable }">
             <div class="test-result-head">
               <span class="tag" :class="cfgTestResult.reachable ? 'tag-success' : 'tag-error'">{{ cfgTestResult.status || 'ERROR' }}</span>
@@ -446,7 +451,7 @@ const cfgTesting = ref(false)
 const cfgTestResult = ref(null)
 const huobaoApiKey = ref('')
 const huobaoSaving = ref(false)
-const cfgForm = reactive({ name: '', provider: '', api_key: '', base_url: '', modelStr: '', service_type: 'text', priority: 0 })
+const cfgForm = reactive({ name: '', provider: '', api_key: '', base_url: '', modelStr: '', service_type: 'text', priority: 0, temperature: '' })
 const serviceTypes = [{ type: 'text', label: '文本' }, { type: 'image', label: '图片' }, { type: 'video', label: '视频' }]
 const providers = ['gemini', 'openai', 'volcengine']
 const providerSelectOptions = computed(() => providers.map(p => ({ label: p, value: p })))
@@ -517,7 +522,7 @@ async function applyHuobaoQuickConfig() {
 function startAddCfg(t) {
   cfgEditId.value = null
   cfgTestResult.value = null
-  Object.assign(cfgForm, { name: '', provider: '', api_key: '', base_url: '', modelStr: '', service_type: t, priority: 0 })
+  Object.assign(cfgForm, { name: '', provider: '', api_key: '', base_url: '', modelStr: '', service_type: t, priority: 0, temperature: '' })
   const firstPreset = presetsByType(t)[0]
   if (firstPreset) applyProviderPreset(t, firstPreset.provider)
   cfgDialog.value = true
@@ -533,6 +538,7 @@ function startEditCfg(c) {
     modelStr: fmtModel(c.model),
     service_type: c.service_type,
     priority: c.priority ?? 0,
+    temperature: c.temperature ?? '',
   })
   cfgDialog.value = true
 }
@@ -570,9 +576,13 @@ async function testExistingCfg(c) {
 async function saveCfg() {
   if (!cfgForm.provider) { toast.warning('选择服务商'); return }
   const models = cfgForm.modelStr.split(',').map(s => s.trim()).filter(Boolean)
+  const temperature = cfgForm.temperature === '' || cfgForm.temperature === null ? null : Number(cfgForm.temperature)
+  if (temperature !== null && (!Number.isFinite(temperature) || temperature < 0 || temperature > 2)) {
+    toast.warning('Temperature 需为 0~2 的数字'); return
+  }
   try {
-    if (cfgEditId.value) await aiConfigAPI.update(cfgEditId.value, { name: cfgForm.name, provider: cfgForm.provider, api_key: cfgForm.api_key, base_url: cfgForm.base_url, model: models, priority: cfgForm.priority })
-    else await aiConfigAPI.create({ service_type: cfgForm.service_type, provider: cfgForm.provider, name: cfgForm.name || `${cfgForm.provider}-${cfgForm.service_type}`, api_key: cfgForm.api_key, base_url: cfgForm.base_url, model: models, priority: cfgForm.priority })
+    if (cfgEditId.value) await aiConfigAPI.update(cfgEditId.value, { name: cfgForm.name, provider: cfgForm.provider, api_key: cfgForm.api_key, base_url: cfgForm.base_url, model: models, priority: cfgForm.priority, temperature })
+    else await aiConfigAPI.create({ service_type: cfgForm.service_type, provider: cfgForm.provider, name: cfgForm.name || `${cfgForm.provider}-${cfgForm.service_type}`, api_key: cfgForm.api_key, base_url: cfgForm.base_url, model: models, priority: cfgForm.priority, temperature })
     cfgDialog.value = false; toast.success('已保存'); loadCfgs()
   } catch (e) { toast.error(e.message) }
 }

--- a/frontend/app/views/drama/episode.vue
+++ b/frontend/app/views/drama/episode.vue
@@ -2006,7 +2006,8 @@ const videoTaskRows = computed(() => sbs.value.map((sb, index) => {
     duration: Number.isFinite(duration) ? duration : 5,
     referenceCount,
     state: videoTaskState(sb),
-    error: videoFailMessage(sb.id),
+    // 只有当前处于失败状态才显示错误,避免重试成功的分镜残留历史错误信息
+    error: videoTaskState(sb) === 'failed' ? videoFailMessage(sb.id) : '',
   }
 }))
 const videoTaskDoneCount = computed(() => videoTaskRows.value.filter(task => task.state === 'done').length)
@@ -2077,6 +2078,25 @@ async function loadGenTasks() {
     const data = await taskAPI.listByEpisode(epId.value)
     genTasks.value = data?.tasks || []
     genMerges.value = data?.merges || []
+
+    // 生成中/失败状态只存在内存里,页面刷新后丢失;从 sys_task 记录按分镜恢复,
+    // 否则已失败的镜头刷新后会退化成"待生成"
+    const videoTasks = genTasks.value
+      .filter(t => t.type === 'video' && t.storyboard_id)
+      .sort((a, b) => String(b.created_at || '').localeCompare(String(a.created_at || '')))
+    const pending = new Set(pendingVideoIds.value)
+    const failed = { ...failedVideoMessages.value }
+    for (const t of videoTasks) {
+      const sbId = t.storyboard_id
+      if (t.status === 'processing' && !hasVid(sbs.value.find(s => s.id === sbId))) {
+        pending.add(sbId)
+      } else if (t.status === 'failed' && !(sbId in failed) && !hasVid(sbs.value.find(s => s.id === sbId))) {
+        // 分镜已有视频(失败后重试成功)时不再报历史错误
+        failed[sbId] = t.error_msg || '生成失败'
+      }
+    }
+    pendingVideoIds.value = [...pending]
+    failedVideoMessages.value = failed
   } catch { /* 静默失败,不打断其他刷新 */ }
 }
 


### PR DESCRIPTION
## 改动概览

### 1. AI 配置支持自定义 temperature
- 后端 `ai_configs` 新增 `temperature` 字段（存于 settings JSON），前端设置页可配置
- 修复 kimi-k2 等固定温度模型报 `invalid temperature: only 0.6 is allowed` 的问题

### 2. 构建与运行环境
- Dockerfile 换国内镜像源（APT/NPM/pip/ffmpeg-static），加速构建
- MySQL 映射端口改为 3307

### 3. 分镜拆解与视频提示词修复（核心）
- **分批保存防截断**：`save_storyboards` 重构为每批最多 8 个、`replace_existing` + 按 shot_number 幂等 upsert，修复模型一次输出 20-30 个分镜导致 JSON 截断、工具调用失败的 bug
- **注入 max_tokens**：fetch 层按 provider 注入（OpenAI `max_tokens` / Gemini `generationConfig.maxOutputTokens`），prompt 硬约束禁止输出推理文本
- **垃圾值过滤**：`update_storyboard` 丢弃模型回传的 `"null"`/`"undefined"` 字符串，防止视频提示词 Agent 回传整行字段时把 description 等字段覆盖成 `"null"`（曾导致 7 个分镜描述丢失）
- **参数约束**：prompt 明确 `update_storyboard` 只传 `storyboard_id` + `video_prompt` 两个键
- 工具调用解析适配 Mastra v1.17 的 `ToolCallChunk` 结构

### 4. 任务状态刷新恢复
- 刷新页面后从 `sys_task` 恢复每个分镜的「生成中/失败」状态，不再一律退回「待生成」
- 启动时把进程重启中断的 `processing` 任务标记为 failed
- 失败后重试成功的分镜不再显示历史错误信息

## 验证
- 分镜拆解：31 个分镜分 4 批成功保存，幂等可重跑
- 视频提示词生成后 description 不再被覆盖
- 容器重建后任务状态正常